### PR TITLE
Update ACI memory allocation format in deployment file

### DIFF
--- a/.github/workflows/prod-deploy.yaml
+++ b/.github/workflows/prod-deploy.yaml
@@ -202,7 +202,7 @@ jobs:
             --registry-login-server ${{ env.ACR_NAME }}.azurecr.io \
             --registry-username $(az acr credential show -n ${{ env.ACR_NAME }} --query username -o tsv) \
             --registry-password $(az acr credential show -n ${{ env.ACR_NAME }} --query "passwords[0].value" -o tsv) \
-            --cpu 1 --memory 1.5Gi \
+            --cpu 1 --memory 1.5 \
             --os-type Linux \
             --ports 8080 \
             --dns-name-label ${{ env.DNS_NAME_LABEL }}


### PR DESCRIPTION
This is to correct the error "ERROR: argument --memory: invalid float value: '1.5Gi'" during deployment