### PR TITLE
Fix Docker Compose and Visual Studio debugging integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-COMPOSE_PROJECT_NAME=taskflowapi

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=taskflowapi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-      - run: dotnet format --verify-no-changes
+      - run: dotnet format TaskFlow.Api.sln --verify-no-changes
   build:
     needs: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-      - run: dotnet build --configuration Release
+      - run: dotnet build TaskFlow.Api.sln --configuration Release
   test:
     needs: lint
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
         with:
           dotnet-version: '10.0.x'
       - name: Run tests with coverage and enforce threshold
-        run: dotnet test --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=./TestResults/coverage.cobertura.xml /p:Exclude="[xunit.*]*%2c[TaskFlow.Api]TaskFlow.Api.Program%2c[TaskFlow.Api]TaskFlow.Api.Migrations.*%2c[TaskFlow.Api]TaskFlow.Api.Middleware.*%2c[TaskFlow.Api]Microsoft.AspNetCore.OpenApi.*%2c[TaskFlow.Api]System.Runtime.CompilerServices.*%2c[TaskFlow.Api]TaskFlow.Api.DTOs.*" /p:Threshold=75 /p:ThresholdType=line /p:ThresholdStat=total
+        run: dotnet test TaskFlow.Api.sln --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=./TestResults/coverage.cobertura.xml /p:Exclude="[xunit.*]*%2c[TaskFlow.Api]TaskFlow.Api.Program%2c[TaskFlow.Api]TaskFlow.Api.Migrations.*%2c[TaskFlow.Api]TaskFlow.Api.Middleware.*%2c[TaskFlow.Api]Microsoft.AspNetCore.OpenApi.*%2c[TaskFlow.Api]System.Runtime.CompilerServices.*%2c[TaskFlow.Api]TaskFlow.Api.DTOs.*" /p:Threshold=75 /p:ThresholdType=line /p:ThresholdStat=total
       - name: Install ReportGenerator
         run: dotnet tool install -g dotnet-reportgenerator-globaltool
       - name: Generate coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,9 @@ storybook-static/
 .Dockerfile.swp
 docker-compose.override.yml
 .env
+!/.env
 .env.*.local
+.claude/settings.local.json
 Thumbs.db
 
 # -----------------------

--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,6 @@ storybook-static/
 .Dockerfile.swp
 docker-compose.override.yml
 .env
-!/.env
 .env.*.local
 .claude/settings.local.json
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,10 @@ dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
 dotnet format --verify-no-changes
 
 # Docker (dev — includes Seq logging UI at http://localhost:5380)
-docker compose up
+docker compose up -d
+
+# Rebuild full image after VS has clobbered it (VS builds to base stage only)
+docker build -t taskflow-api:dev -f TaskFlow.Api/Dockerfile .
 
 # Docker (production)
 docker compose -f docker-compose.prod.yml up
@@ -50,6 +53,16 @@ Tests mirror the main project structure: `Controllers/V1/`, `Services/`, `Reposi
 - Repository tests use `Microsoft.EntityFrameworkCore.InMemory` — no mocks for the DB layer.
 - Service and controller tests use Moq to mock the layer below.
 - CI enforces **75% line coverage** minimum (`ci.yml`).
+
+## Visual Studio Docker Compose Debugging
+
+**Workflow:** Run `docker compose up -d` in the terminal first, then press F5 in VS. VS attaches to the running container rather than starting one from scratch.
+
+**Required before each VS session:** Close VS completely, ensure no `taskflow-api` or `taskflow-seq` containers are running (`docker compose down`), then reopen VS and press F5. Skipping the restart causes VS to loop endlessly on `docker ps` polling.
+
+**VS rebuilds the image on warmup:** When a solution loads, VS rebuilds `taskflow-api:dev` to the `base` stage only (no app DLLs). After any VS session, run `docker build -t taskflow-api:dev -f TaskFlow.Api/Dockerfile .` to restore the full image before using `docker compose up -d` from the CLI.
+
+**MCR pull failures (IPv6):** If `mcr.microsoft.com` pulls fail with TLS reset, add `150.171.70.10 mcr.microsoft.com` to `C:\Windows\System32\drivers\etc\hosts` to force IPv4.
 
 ## Key Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Run
+dotnet run --project TaskFlow.Api
+
+# Test (all)
+dotnet test
+
+# Test (single)
+dotnet test --filter "FullyQualifiedName~TaskServiceTests.GetAllTasksAsync_ShouldReturnAllTasks"
+
+# Test with coverage
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+
+# Format check (CI enforces this)
+dotnet format --verify-no-changes
+
+# Docker (dev — includes Seq logging UI at http://localhost:5380)
+docker compose up
+
+# Docker (production)
+docker compose -f docker-compose.prod.yml up
+```
+
+## Architecture
+
+**Stack:** .NET 10, EF Core + SQLite, FluentValidation, OpenTelemetry → Seq, xUnit/Moq/FluentAssertions, Scalar/OpenAPI
+
+**Layered flow:** `Controller → Service → Repository → EF Core (SQLite)`
+
+**Extension method pattern** — `Program.cs` stays clean by delegating all service registration to methods in `Extensions/`. Each extension file owns one concern (persistence, versioning, health checks, OpenTelemetry, validation, JSON, OpenAPI). Adding a new cross-cutting concern means a new extension file, not touching `Program.cs`.
+
+**API versioning** uses both URL path (`/api/v1/TaskItems`) and request header (`x-api-version`). Controllers live in `Controllers/V1/` and are decorated with `[ApiVersion("1.0")]`.
+
+**Validation** is handled by FluentValidation validators in `Validators/` and applied globally via middleware registered in `ValidationServiceExtensions`. Controllers don't manually invoke validators.
+
+**Health checks:** Three endpoints — `/health` (combined), `/health/ready` (DB connectivity, used as K8s readiness probe), `/health/live` (always up, liveness probe). Custom JSON writer in `HealthChecks/`.
+
+**Migrations run on startup** when `Database:MigrateOnStartup` is `true` (default in Docker; disabled in production deploy if needed).
+
+## Testing
+
+Tests mirror the main project structure: `Controllers/V1/`, `Services/`, `Repositories/`, `Validators/`, `HealthChecks/`, `Extensions/`.
+
+- Repository tests use `Microsoft.EntityFrameworkCore.InMemory` — no mocks for the DB layer.
+- Service and controller tests use Moq to mock the layer below.
+- CI enforces **75% line coverage** minimum (`ci.yml`).
+
+## Key Configuration
+
+`appsettings.Development.json` uses a local relative DB path (`./data/tasks.dev.db`). The container uses `/app/data/tasks.db`. The `OpenTelemetry` section configures the OTLP export endpoint and Seq API key — override via environment variables or `.env` file (gitignored).
+
+## CI/CD
+
+GitHub Actions workflows: `ci.yml` (lint → build → test → smoke test), `codeql.yml`, `container-scan.yml` (Trivy), `prod-deploy.yaml` / `qa-deploy.yaml` (Azure ACI via OIDC — no stored credentials).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,9 @@ Tests mirror the main project structure: `Controllers/V1/`, `Services/`, `Reposi
 
 ## Key Configuration
 
-`appsettings.Development.json` uses a local relative DB path (`./data/tasks.dev.db`). The container uses `/app/data/tasks.db`. The `OpenTelemetry` section configures the OTLP export endpoint and Seq API key — override via environment variables or `.env` file (gitignored).
+`appsettings.Development.json` uses a local relative DB path (`./data/tasks.dev.db`). The container uses `/app/data/tasks.db`. The `OpenTelemetry` section configures the OTLP export endpoint — override via environment variables or a local `TaskFlow.Api/.env` file (gitignored).
+
+Create a root `.env` with `COMPOSE_PROJECT_NAME=taskflowapi` for consistent CLI project naming — this file is gitignored and must be created locally.
 
 ## CI/CD
 

--- a/TaskFlow.Api.sln
+++ b/TaskFlow.Api.sln
@@ -37,6 +37,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{8D4B7FAA-9
 		docs\VOLUME_TESTING.md = docs\VOLUME_TESTING.md
 	EndProjectSection
 EndProject
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{A451F2CD-676B-4552-9A25-D89F92A11AA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,12 @@ Global
 		{F6A54A72-2C70-4FF7-8572-1AB0EB9B8637}.Release|x64.Build.0 = Release|Any CPU
 		{F6A54A72-2C70-4FF7-8572-1AB0EB9B8637}.Release|x86.ActiveCfg = Release|Any CPU
 		{F6A54A72-2C70-4FF7-8572-1AB0EB9B8637}.Release|x86.Build.0 = Release|Any CPU
+		{A451F2CD-676B-4552-9A25-D89F92A11AA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A451F2CD-676B-4552-9A25-D89F92A11AA5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A451F2CD-676B-4552-9A25-D89F92A11AA5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A451F2CD-676B-4552-9A25-D89F92A11AA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A451F2CD-676B-4552-9A25-D89F92A11AA5}.Release|x64.ActiveCfg = Release|Any CPU
+		{A451F2CD-676B-4552-9A25-D89F92A11AA5}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TaskFlow.Api/.env.example
+++ b/TaskFlow.Api/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in the values.
+# .env is excluded from source control (.gitignore).
+
+# OpenTelemetry header injected into every OTLP export request.
+# For Seq, use the format: X-Seq-ApiKey=<your-api-key>
+# The API key must exist in your Seq instance (Settings > API Keys).
+OpenTelemetry__Header=X-Seq-ApiKey=your-seq-api-key-here

--- a/TaskFlow.Api/Extensions/OpenTelemetryServiceExtensions.cs
+++ b/TaskFlow.Api/Extensions/OpenTelemetryServiceExtensions.cs
@@ -102,7 +102,12 @@ public static class OpenTelemetryServiceExtensions
                 {
                     otlp.Headers = header;
                 }
-                processor.ExportProcessorType = ExportProcessorType.Batch;
+                // Simple processor in Development exports each record immediately, so logs
+                // are visible in Seq without delay and are not lost when VS stops the
+                // container with SIGKILL before the batch can flush.
+                processor.ExportProcessorType = environment.IsDevelopment()
+                    ? ExportProcessorType.Simple
+                    : ExportProcessorType.Batch;
             });
         });
 

--- a/TaskFlow.Api/Extensions/OpenTelemetryServiceExtensions.cs
+++ b/TaskFlow.Api/Extensions/OpenTelemetryServiceExtensions.cs
@@ -1,3 +1,4 @@
+using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -93,7 +94,7 @@ public static class OpenTelemetryServiceExtensions
             options.IncludeScopes = true;
             options.ParseStateValues = true;
 
-            options.AddOtlpExporter(otlp =>
+            options.AddOtlpExporter((otlp, processor) =>
             {
                 otlp.Endpoint = new Uri(baseEndpoint + "/v1/logs");
                 otlp.Protocol = protocol;
@@ -101,6 +102,7 @@ public static class OpenTelemetryServiceExtensions
                 {
                     otlp.Headers = header;
                 }
+                processor.ExportProcessorType = ExportProcessorType.Batch;
             });
         });
 

--- a/TaskFlow.Api/Properties/launchSettings.json
+++ b/TaskFlow.Api/Properties/launchSettings.json
@@ -9,7 +9,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HTTP_PORTS": "8080",
         "Database__MigrateOnStartup": "true",
-        "DOTNET_RUNNING_IN_CONTAINER": "true"
+        "DOTNET_RUNNING_IN_CONTAINER": "true",
+        "ConnectionStrings__DefaultConnection": "Data Source=/tmp/tasks.dev.db"
       },
       "publishAllPorts": false,
       "httpPort": 8080,

--- a/TaskFlow.Api/Properties/launchSettings.json
+++ b/TaskFlow.Api/Properties/launchSettings.json
@@ -11,8 +11,7 @@
         "Database__MigrateOnStartup": "true",
         "DOTNET_RUNNING_IN_CONTAINER": "true",
         "ConnectionStrings__DefaultConnection": "Data Source=/tmp/tasks.dev.db",
-        "OpenTelemetry__Endpoint": "http://host.docker.internal:5341/ingest/otlp",
-        "OpenTelemetry__Header": "X-Seq-ApiKey=pgR7FS6RWVDkIXUtHg3h"
+        "OpenTelemetry__Endpoint": "http://host.docker.internal:5341/ingest/otlp"
       },
       "publishAllPorts": false,
       "httpPort": 8080,

--- a/TaskFlow.Api/Properties/launchSettings.json
+++ b/TaskFlow.Api/Properties/launchSettings.json
@@ -10,7 +10,9 @@
         "ASPNETCORE_HTTP_PORTS": "8080",
         "Database__MigrateOnStartup": "true",
         "DOTNET_RUNNING_IN_CONTAINER": "true",
-        "ConnectionStrings__DefaultConnection": "Data Source=/tmp/tasks.dev.db"
+        "ConnectionStrings__DefaultConnection": "Data Source=/tmp/tasks.dev.db",
+        "OpenTelemetry__Endpoint": "http://host.docker.internal:5341/ingest/otlp",
+        "OpenTelemetry__Header": "X-Seq-ApiKey=pgR7FS6RWVDkIXUtHg3h"
       },
       "publishAllPorts": false,
       "httpPort": 8080,

--- a/TaskFlow.Api/TaskFlow.Api.csproj
+++ b/TaskFlow.Api/TaskFlow.Api.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..</DockerfileContext>
     <DockerfileFile>Dockerfile</DockerfileFile>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <UserSecretsId>1ae9a9e2-f9fc-402a-95ed-01ec1cfdf34b</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TaskFlow.Api/TaskFlow.Api.csproj
+++ b/TaskFlow.Api/TaskFlow.Api.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileFile>Dockerfile</DockerfileFile>
+    <DockerPullDependentImages>false</DockerPullDependentImages>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/TaskFlow.Api/TaskFlow.Api.csproj
+++ b/TaskFlow.Api/TaskFlow.Api.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileFile>Dockerfile</DockerfileFile>
-    <DockerPullDependentImages>false</DockerPullDependentImages>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>2.1</ProjectVersion>
+    <DockerTargetOS>Linux</DockerTargetOS>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+    <None Include=".dockerignore" />
+  </ItemGroup>
+</Project>

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -4,6 +4,8 @@
     <ProjectVersion>2.1</ProjectVersion>
     <DockerTargetOS>Linux</DockerTargetOS>
     <DockerComposeServiceName>taskflow-api</DockerComposeServiceName>
+    <DockerComposeBuildAction>None</DockerComposeBuildAction>
+    <DockerPullDependentImages>false</DockerPullDependentImages>
   </PropertyGroup>
   <ItemGroup>
     <None Include="docker-compose.override.yml">

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <ProjectVersion>2.1</ProjectVersion>
     <DockerTargetOS>Linux</DockerTargetOS>
+    <DockerComposeServiceName>taskflow-api</DockerComposeServiceName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="docker-compose.override.yml">

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -3,9 +3,8 @@
   <PropertyGroup Label="Globals">
     <ProjectVersion>2.1</ProjectVersion>
     <DockerTargetOS>Linux</DockerTargetOS>
-    <DockerComposeServiceName>taskflow-api</DockerComposeServiceName>
-    <DockerComposeBuildAction>None</DockerComposeBuildAction>
-    <DockerPullDependentImages>false</DockerPullDependentImages>
+    <DockerServiceName>taskflow-api</DockerServiceName>
+    <DependencyAwareStart>true</DependencyAwareStart>
   </PropertyGroup>
   <ItemGroup>
     <None Include="docker-compose.override.yml">

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -7,9 +7,6 @@
     <DependencyAwareStart>true</DependencyAwareStart>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="docker-compose.override.yml">
-      <DependentUpon>docker-compose.yml</DependentUpon>
-    </None>
     <None Include="docker-compose.yml" />
     <None Include=".dockerignore" />
   </ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   seq:
     image: datalust/seq:latest
-    container_name: taskflow-seq
     ports:
       - "5341:5341"
       - "5380:80"
@@ -15,7 +14,6 @@ services:
     build:
       context: .
       dockerfile: TaskFlow.Api/Dockerfile
-    container_name: taskflow-api
     env_file:
       - TaskFlow.Api/.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       context: .
       dockerfile: TaskFlow.Api/Dockerfile
     env_file:
-      - TaskFlow.Api/.env
+      - path: TaskFlow.Api/.env
+        required: false
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       context: .
       dockerfile: TaskFlow.Api/Dockerfile
     container_name: taskflow-api
+    env_file:
+      - TaskFlow.Api/.env
     ports:
       - "8080:8080"
     environment:
@@ -20,6 +22,7 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - DOTNET_RUNNING_IN_CONTAINER=true
       - Database__MigrateOnStartup=true
+      - OpenTelemetry__Endpoint=http://seq:5341/ingest/otlp
     volumes:
       - taskflow-data:/app/data
       - taskflow-logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,17 @@
 services:
   seq:
+    container_name: taskflow-seq
     image: datalust/seq:latest
     ports:
       - "5341:5341"
       - "5380:80"
     environment:
       - ACCEPT_EULA=Y
-      - SEQ_FIRSTRUN_ADMINPASSWORD=admin
+      - SEQ_FIRSTRUN_NOAUTHENTICATION=true
     restart: unless-stopped
 
   taskflow-api:
+    container_name: taskflow-api
     image: taskflow-api:dev
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 services:
+  seq:
+    image: datalust/seq:latest
+    container_name: taskflow-seq
+    environment:
+      - ACCEPT_EULA=Y
+      - SEQ_FIRSTRUN_ADMINPASSWORD=admin
+    restart: unless-stopped
+
   taskflow-api:
     image: taskflow-api:dev
     build:
@@ -22,6 +30,9 @@ services:
       retries: 3
       start_period: 40s
     restart: unless-stopped
+    depends_on:
+      seq:
+        condition: service_started
 
 volumes:
   taskflow-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   seq:
     image: datalust/seq:latest
     container_name: taskflow-seq
+    ports:
+      - "5341:5341"
+      - "5380:80"
     environment:
       - ACCEPT_EULA=Y
       - SEQ_FIRSTRUN_ADMINPASSWORD=admin


### PR DESCRIPTION
## Summary

- Fix Docker Compose so `docker compose up -d` reliably starts both `taskflow-api` and `seq` containers
- Disable Seq authentication on first run (`SEQ_FIRSTRUN_NOAUTHENTICATION=true`) so the UI opens without a login prompt
- Replace undocumented `.dcproj` properties with correct documented VS properties (`DockerServiceName`, `DependencyAwareStart`)
- Add OpenTelemetry → Seq integration with OTLP export
- Add `CLAUDE.md` with architecture notes, commands, and VS Docker debugging workflow

## VS Docker Compose debugging workflow

1. `docker compose down` — ensure no conflicting containers
2. Close and reopen Visual Studio
3. `docker compose up -d` in terminal
4. Press F5 — VS attaches to the running container

**Known quirk:** VS rebuilds `taskflow-api:dev` to the `base` stage (no app DLLs) on solution load. After any VS session, run `docker build -t taskflow-api:dev -f TaskFlow.Api/Dockerfile .` to restore the full image for CLI use.

## Test plan

- [ ] `docker compose up -d` starts both services without errors
- [ ] Seq UI accessible at http://localhost:5380 with no login prompt
- [ ] API health check responds at http://localhost:8080/health
- [ ] F5 debugger attaches after VS restart workflow
- [ ] `dotnet test` passes with coverage above 75%

🤖 Generated with [Claude Code](https://claude.com/claude-code)