### PR TITLE
Add Notes feature with CRUD endpoints nested under tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,7 +210,7 @@ TaskFlow.Api/tasks.db-wal
 *.db-shm
 *.db-wal
 
-# Ignore data directory created by docker-compose for volume mounts
-data/
+# Ignore data directory created by docker-compose for volume mounts (root only)
+/data/
 
 # End of file

--- a/TaskFlow.Api.Tests/Controllers/V1/NotesControllerV1Tests.cs
+++ b/TaskFlow.Api.Tests/Controllers/V1/NotesControllerV1Tests.cs
@@ -1,0 +1,230 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using TaskFlow.Api.Controllers.V1;
+using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Services;
+
+namespace TaskFlow.Api.Tests.Controllers.V1;
+
+public class NotesControllerV1Tests
+{
+    private readonly Mock<INoteService> _mockNoteService;
+    private readonly Mock<ITaskService> _mockTaskService;
+    private readonly Mock<IValidator<Note>> _mockValidator;
+    private readonly NotesController _controller;
+
+    public NotesControllerV1Tests()
+    {
+        _mockNoteService = new Mock<INoteService>();
+        _mockTaskService = new Mock<ITaskService>();
+        _mockValidator = new Mock<IValidator<Note>>();
+        _controller = new NotesController(_mockNoteService.Object, _mockTaskService.Object, _mockValidator.Object);
+    }
+
+    // --- GET all ---
+
+    [Fact]
+    public async Task GetAll_ShouldReturnOkWithNotes_WhenTaskExists()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        var notes = new List<Note>
+        {
+            new() { Id = 1, Content = "Note 1", TaskItemId = 1, CreatedAt = DateTime.UtcNow },
+            new() { Id = 2, Content = "Note 2", TaskItemId = 1, CreatedAt = DateTime.UtcNow }
+        };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNotesForTaskAsync(1)).ReturnsAsync(notes);
+
+        var result = await _controller.GetAll(1);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dtos = ok.Value.Should().BeAssignableTo<IEnumerable<NoteResponseDto>>().Subject;
+        dtos.Should().HaveCount(2);
+        _mockNoteService.Verify(s => s.GetNotesForTaskAsync(1), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAll_ShouldReturnNotFound_WhenTaskDoesNotExist()
+    {
+        _mockTaskService.Setup(s => s.GetTaskAsync(99)).ReturnsAsync((TaskItem?)null);
+
+        var result = await _controller.GetAll(99);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+        _mockNoteService.Verify(s => s.GetNotesForTaskAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    // --- GET single ---
+
+    [Fact]
+    public async Task Get_ShouldReturnOkWithNote_WhenNoteExists()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        var note = new Note { Id = 5, Content = "My note", TaskItemId = 1, CreatedAt = DateTime.UtcNow };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNoteAsync(1, 5)).ReturnsAsync(note);
+
+        var result = await _controller.Get(1, 5);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<NoteResponseDto>().Subject;
+        dto.Id.Should().Be(5);
+        dto.Content.Should().Be("My note");
+        dto.TaskItemId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnNotFound_WhenTaskDoesNotExist()
+    {
+        _mockTaskService.Setup(s => s.GetTaskAsync(99)).ReturnsAsync((TaskItem?)null);
+
+        var result = await _controller.Get(99, 1);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnNotFound_WhenNoteDoesNotExist()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNoteAsync(1, 99)).ReturnsAsync((Note?)null);
+
+        var result = await _controller.Get(1, 99);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // --- POST ---
+
+    [Fact]
+    public async Task Create_ShouldReturnCreated_WhenValid()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        var createDto = new CreateNoteDto { Content = "New note" };
+        var created = new Note { Id = 3, Content = "New note", TaskItemId = 1, CreatedAt = DateTime.UtcNow };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockValidator.Setup(v => v.ValidateAsync(It.IsAny<Note>(), default))
+            .ReturnsAsync(new ValidationResult());
+        _mockNoteService.Setup(s => s.CreateNoteAsync(It.IsAny<Note>())).ReturnsAsync(created);
+
+        var result = await _controller.Create(1, createDto);
+
+        var createdResult = result.Result.Should().BeOfType<CreatedAtRouteResult>().Subject;
+        var dto = createdResult.Value.Should().BeOfType<NoteResponseDto>().Subject;
+        dto.Id.Should().Be(3);
+        dto.Content.Should().Be("New note");
+        dto.TaskItemId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnNotFound_WhenTaskDoesNotExist()
+    {
+        _mockTaskService.Setup(s => s.GetTaskAsync(99)).ReturnsAsync((TaskItem?)null);
+
+        var result = await _controller.Create(99, new CreateNoteDto { Content = "Note" });
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+        _mockNoteService.Verify(s => s.CreateNoteAsync(It.IsAny<Note>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnBadRequest_WhenValidationFails()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockValidator.Setup(v => v.ValidateAsync(It.IsAny<Note>(), default))
+            .ReturnsAsync(new ValidationResult(
+                [new ValidationFailure("Content", "Content is required.")]));
+
+        var result = await _controller.Create(1, new CreateNoteDto { Content = string.Empty });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _mockNoteService.Verify(s => s.CreateNoteAsync(It.IsAny<Note>()), Times.Never);
+    }
+
+    // --- PUT ---
+
+    [Fact]
+    public async Task Update_ShouldReturnOk_WhenValid()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        var existing = new Note { Id = 5, Content = "Old", TaskItemId = 1, CreatedAt = DateTime.UtcNow };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNoteAsync(1, 5)).ReturnsAsync(existing);
+        _mockValidator.Setup(v => v.ValidateAsync(It.IsAny<Note>(), default))
+            .ReturnsAsync(new ValidationResult());
+        _mockNoteService.Setup(s => s.UpdateNoteAsync(It.IsAny<Note>())).Returns(Task.CompletedTask);
+
+        var result = await _controller.Update(1, 5, new UpdateNoteDto { Content = "Updated" });
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<NoteResponseDto>().Subject;
+        dto.Content.Should().Be("Updated");
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturnNotFound_WhenTaskDoesNotExist()
+    {
+        _mockTaskService.Setup(s => s.GetTaskAsync(99)).ReturnsAsync((TaskItem?)null);
+
+        var result = await _controller.Update(99, 1, new UpdateNoteDto { Content = "x" });
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturnNotFound_WhenNoteDoesNotExist()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNoteAsync(1, 99)).ReturnsAsync((Note?)null);
+
+        var result = await _controller.Update(1, 99, new UpdateNoteDto { Content = "x" });
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // --- DELETE ---
+
+    [Fact]
+    public async Task Delete_ShouldReturnNoContent_WhenNoteExists()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        var note = new Note { Id = 5, Content = "Note", TaskItemId = 1 };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNoteAsync(1, 5)).ReturnsAsync(note);
+        _mockNoteService.Setup(s => s.DeleteNoteAsync(5)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Delete(1, 5);
+
+        result.Should().BeOfType<NoContentResult>();
+        _mockNoteService.Verify(s => s.DeleteNoteAsync(5), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldReturnNotFound_WhenTaskDoesNotExist()
+    {
+        _mockTaskService.Setup(s => s.GetTaskAsync(99)).ReturnsAsync((TaskItem?)null);
+
+        var result = await _controller.Delete(99, 1);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Delete_ShouldReturnNotFound_WhenNoteDoesNotExist()
+    {
+        var task = new TaskItem { Id = 1, Title = "Task" };
+        _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
+        _mockNoteService.Setup(s => s.GetNoteAsync(1, 99)).ReturnsAsync((Note?)null);
+
+        var result = await _controller.Delete(1, 99);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+}

--- a/TaskFlow.Api.Tests/Controllers/V1/NotesControllerV1Tests.cs
+++ b/TaskFlow.Api.Tests/Controllers/V1/NotesControllerV1Tests.cs
@@ -198,12 +198,12 @@ public class NotesControllerV1Tests
         var note = new Note { Id = 5, Content = "Note", TaskItemId = 1 };
         _mockTaskService.Setup(s => s.GetTaskAsync(1)).ReturnsAsync(task);
         _mockNoteService.Setup(s => s.GetNoteAsync(1, 5)).ReturnsAsync(note);
-        _mockNoteService.Setup(s => s.DeleteNoteAsync(5)).Returns(Task.CompletedTask);
+        _mockNoteService.Setup(s => s.DeleteNoteAsync(1, 5)).Returns(Task.CompletedTask);
 
         var result = await _controller.Delete(1, 5);
 
         result.Should().BeOfType<NoContentResult>();
-        _mockNoteService.Verify(s => s.DeleteNoteAsync(5), Times.Once);
+        _mockNoteService.Verify(s => s.DeleteNoteAsync(1, 5), Times.Once);
     }
 
     [Fact]

--- a/TaskFlow.Api.Tests/Repositories/NoteRepositoryTests.cs
+++ b/TaskFlow.Api.Tests/Repositories/NoteRepositoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using TaskFlow.Api.Data;
 using TaskFlow.Api.Models;
@@ -149,7 +150,7 @@ public class NoteRepositoryTests
         await context.SaveChangesAsync();
         var repo = new NoteRepository(context);
 
-        await repo.DeleteAsync(note.Id);
+        await repo.DeleteAsync(1, note.Id);
 
         var deleted = await context.Notes.FindAsync(note.Id);
         deleted.Should().BeNull();
@@ -161,8 +162,59 @@ public class NoteRepositoryTests
         using var context = CreateInMemoryContext();
         var repo = new NoteRepository(context);
 
-        var act = async () => await repo.DeleteAsync(999);
+        var act = async () => await repo.DeleteAsync(1, 999);
 
         await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldNotDeleteNote_WhenNoteDoesNotBelongToTask()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        SeedTask(context, 2);
+        var note = new Note { Content = "Task 2 note", TaskItemId = 2 };
+        context.Notes.Add(note);
+        await context.SaveChangesAsync();
+        var repo = new NoteRepository(context);
+
+        await repo.DeleteAsync(1, note.Id);
+
+        var stillExists = await context.Notes.FindAsync(note.Id);
+        stillExists.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_ShouldCascadeDeleteNotes()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<TaskDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using (var context = new TaskDbContext(options))
+        {
+            await context.Database.EnsureCreatedAsync();
+            var task = new TaskItem { Title = "Task with notes" };
+            context.TaskItems.Add(task);
+            await context.SaveChangesAsync();
+            context.Notes.AddRange(
+                new Note { Content = "Note 1", TaskItemId = task.Id },
+                new Note { Content = "Note 2", TaskItemId = task.Id }
+            );
+            await context.SaveChangesAsync();
+
+            context.TaskItems.Remove(task);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = new TaskDbContext(options))
+        {
+            var remainingNotes = await context.Notes.ToListAsync();
+            remainingNotes.Should().BeEmpty();
+        }
+
+        connection.Close();
     }
 }

--- a/TaskFlow.Api.Tests/Repositories/NoteRepositoryTests.cs
+++ b/TaskFlow.Api.Tests/Repositories/NoteRepositoryTests.cs
@@ -1,0 +1,168 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using TaskFlow.Api.Data;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repositories;
+
+namespace TaskFlow.Api.Tests.Repositories;
+
+public class NoteRepositoryTests
+{
+    private static TaskDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<TaskDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new TaskDbContext(options);
+    }
+
+    private static TaskItem SeedTask(TaskDbContext context, int id = 1)
+    {
+        var task = new TaskItem { Id = id, Title = $"Task {id}" };
+        context.TaskItems.Add(task);
+        context.SaveChanges();
+        return task;
+    }
+
+    [Fact]
+    public async Task GetAllByTaskIdAsync_ShouldReturnNotesForTask()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        SeedTask(context, 2);
+        context.Notes.AddRange(
+            new Note { Content = "Note A", TaskItemId = 1 },
+            new Note { Content = "Note B", TaskItemId = 1 },
+            new Note { Content = "Note C", TaskItemId = 2 }
+        );
+        await context.SaveChangesAsync();
+        var repo = new NoteRepository(context);
+
+        var result = await repo.GetAllByTaskIdAsync(1);
+
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(n => n.TaskItemId.Should().Be(1));
+    }
+
+    [Fact]
+    public async Task GetAllByTaskIdAsync_ShouldReturnEmpty_WhenTaskHasNoNotes()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        var repo = new NoteRepository(context);
+
+        var result = await repo.GetAllByTaskIdAsync(1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNote_WhenNoteExistsForTask()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        var note = new Note { Content = "Test note", TaskItemId = 1 };
+        context.Notes.Add(note);
+        await context.SaveChangesAsync();
+        var repo = new NoteRepository(context);
+
+        var result = await repo.GetByIdAsync(1, note.Id);
+
+        result.Should().NotBeNull();
+        result!.Content.Should().Be("Test note");
+        result.TaskItemId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenNoteDoesNotBelongToTask()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        SeedTask(context, 2);
+        var note = new Note { Content = "Task 2 note", TaskItemId = 2 };
+        context.Notes.Add(note);
+        await context.SaveChangesAsync();
+        var repo = new NoteRepository(context);
+
+        var result = await repo.GetByIdAsync(1, note.Id);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenNoteDoesNotExist()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        var repo = new NoteRepository(context);
+
+        var result = await repo.GetByIdAsync(1, 999);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldAddNoteAndReturnIt()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        var repo = new NoteRepository(context);
+        var note = new Note { Content = "New note", TaskItemId = 1 };
+
+        var result = await repo.AddAsync(note);
+
+        result.Id.Should().BeGreaterThan(0);
+        result.Content.Should().Be("New note");
+        result.TaskItemId.Should().Be(1);
+        result.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+
+        var saved = await context.Notes.FindAsync(result.Id);
+        saved.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateNoteContent()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        var note = new Note { Content = "Original", TaskItemId = 1 };
+        context.Notes.Add(note);
+        await context.SaveChangesAsync();
+        var repo = new NoteRepository(context);
+
+        note.Content = "Updated";
+        await repo.UpdateAsync(note);
+
+        var updated = await context.Notes.FindAsync(note.Id);
+        updated!.Content.Should().Be("Updated");
+        updated.UpdatedAt.Should().NotBeNull();
+        updated.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveNote_WhenNoteExists()
+    {
+        using var context = CreateInMemoryContext();
+        SeedTask(context, 1);
+        var note = new Note { Content = "To delete", TaskItemId = 1 };
+        context.Notes.Add(note);
+        await context.SaveChangesAsync();
+        var repo = new NoteRepository(context);
+
+        await repo.DeleteAsync(note.Id);
+
+        var deleted = await context.Notes.FindAsync(note.Id);
+        deleted.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldNotThrow_WhenNoteDoesNotExist()
+    {
+        using var context = CreateInMemoryContext();
+        var repo = new NoteRepository(context);
+
+        var act = async () => await repo.DeleteAsync(999);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/TaskFlow.Api.Tests/Services/NoteServiceTests.cs
+++ b/TaskFlow.Api.Tests/Services/NoteServiceTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Moq;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repositories;
+using TaskFlow.Api.Services;
+
+namespace TaskFlow.Api.Tests.Services;
+
+public class NoteServiceTests
+{
+    private readonly Mock<INoteRepository> _mockRepo;
+    private readonly NoteService _service;
+
+    public NoteServiceTests()
+    {
+        _mockRepo = new Mock<INoteRepository>();
+        _service = new NoteService(_mockRepo.Object);
+    }
+
+    [Fact]
+    public async Task GetNotesForTaskAsync_ShouldReturnNotes()
+    {
+        var notes = new List<Note>
+        {
+            new() { Id = 1, Content = "Note 1", TaskItemId = 1 },
+            new() { Id = 2, Content = "Note 2", TaskItemId = 1 }
+        };
+        _mockRepo.Setup(r => r.GetAllByTaskIdAsync(1)).ReturnsAsync(notes);
+
+        var result = await _service.GetNotesForTaskAsync(1);
+
+        result.Should().BeEquivalentTo(notes);
+        _mockRepo.Verify(r => r.GetAllByTaskIdAsync(1), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetNoteAsync_ShouldReturnNote_WhenNoteExists()
+    {
+        var note = new Note { Id = 1, Content = "Note 1", TaskItemId = 1 };
+        _mockRepo.Setup(r => r.GetByIdAsync(1, 1)).ReturnsAsync(note);
+
+        var result = await _service.GetNoteAsync(1, 1);
+
+        result.Should().BeEquivalentTo(note);
+        _mockRepo.Verify(r => r.GetByIdAsync(1, 1), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetNoteAsync_ShouldReturnNull_WhenNoteDoesNotExist()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(1, 999)).ReturnsAsync((Note?)null);
+
+        var result = await _service.GetNoteAsync(1, 999);
+
+        result.Should().BeNull();
+        _mockRepo.Verify(r => r.GetByIdAsync(1, 999), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNoteAsync_ShouldCreateAndReturnNote()
+    {
+        var note = new Note { Content = "New note", TaskItemId = 1 };
+        var created = new Note { Id = 1, Content = "New note", TaskItemId = 1 };
+        _mockRepo.Setup(r => r.AddAsync(note)).ReturnsAsync(created);
+
+        var result = await _service.CreateNoteAsync(note);
+
+        result.Should().BeEquivalentTo(created);
+        _mockRepo.Verify(r => r.AddAsync(note), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateNoteAsync_ShouldCallRepositoryUpdate()
+    {
+        var note = new Note { Id = 1, Content = "Updated", TaskItemId = 1 };
+        _mockRepo.Setup(r => r.UpdateAsync(note)).Returns(Task.CompletedTask);
+
+        await _service.UpdateNoteAsync(note);
+
+        _mockRepo.Verify(r => r.UpdateAsync(note), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteNoteAsync_ShouldCallRepositoryDelete()
+    {
+        _mockRepo.Setup(r => r.DeleteAsync(1)).Returns(Task.CompletedTask);
+
+        await _service.DeleteNoteAsync(1);
+
+        _mockRepo.Verify(r => r.DeleteAsync(1), Times.Once);
+    }
+}

--- a/TaskFlow.Api.Tests/Services/NoteServiceTests.cs
+++ b/TaskFlow.Api.Tests/Services/NoteServiceTests.cs
@@ -83,10 +83,10 @@ public class NoteServiceTests
     [Fact]
     public async Task DeleteNoteAsync_ShouldCallRepositoryDelete()
     {
-        _mockRepo.Setup(r => r.DeleteAsync(1)).Returns(Task.CompletedTask);
+        _mockRepo.Setup(r => r.DeleteAsync(1, 5)).Returns(Task.CompletedTask);
 
-        await _service.DeleteNoteAsync(1);
+        await _service.DeleteNoteAsync(1, 5);
 
-        _mockRepo.Verify(r => r.DeleteAsync(1), Times.Once);
+        _mockRepo.Verify(r => r.DeleteAsync(1, 5), Times.Once);
     }
 }

--- a/TaskFlow.Api.Tests/TaskFlow.Api.Tests.csproj
+++ b/TaskFlow.Api.Tests/TaskFlow.Api.Tests.csproj
@@ -21,6 +21,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/TaskFlow.Api.Tests/Validators/NoteValidatorTests.cs
+++ b/TaskFlow.Api.Tests/Validators/NoteValidatorTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Validators;
+
+namespace TaskFlow.Api.Tests.Validators;
+
+public class NoteValidatorTests
+{
+    private readonly NoteValidator _validator;
+
+    public NoteValidatorTests()
+    {
+        _validator = new NoteValidator();
+    }
+
+    [Fact]
+    public async Task Validate_ShouldPass_WhenNoteIsValid()
+    {
+        var note = new Note { Content = "This is a valid note.", TaskItemId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ShouldFail_WhenContentIsEmpty()
+    {
+        var note = new Note { Content = string.Empty, TaskItemId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Content" &&
+            e.ErrorMessage == "Content is required.");
+    }
+
+    [Fact]
+    public async Task Validate_ShouldFail_WhenContentExceedsMaxLength()
+    {
+        var note = new Note { Content = new string('a', 2001), TaskItemId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Content" &&
+            e.ErrorMessage == "Content must not exceed 2000 characters.");
+    }
+
+    [Fact]
+    public async Task Validate_ShouldPass_WhenContentIsExactly2000Characters()
+    {
+        var note = new Note { Content = new string('a', 2000), TaskItemId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+}

--- a/TaskFlow.Api/Controllers/V1/NotesController.cs
+++ b/TaskFlow.Api/Controllers/V1/NotesController.cs
@@ -9,7 +9,7 @@ namespace TaskFlow.Api.Controllers.V1;
 
 [ApiController]
 [ApiVersion("1.0")]
-[Route("api/v{version:apiVersion}/taskitems/{taskId}/notes")]
+[Route("api/v{version:apiVersion}/TaskItems/{taskId}/notes")]
 public class NotesController(INoteService noteService, ITaskService taskService, IValidator<Note> validator) : ControllerBase
 {
     private const string GetNoteRouteName = "GetNoteV1";
@@ -18,7 +18,7 @@ public class NotesController(INoteService noteService, ITaskService taskService,
     private readonly ITaskService _taskService = taskService;
     private readonly IValidator<Note> _validator = validator;
 
-    // GET: api/v1/taskitems/{taskId}/notes
+    // GET: api/v1/TaskItems/{taskId}/notes
     [HttpGet]
     public async Task<ActionResult<IEnumerable<NoteResponseDto>>> GetAll(int taskId)
     {
@@ -32,7 +32,7 @@ public class NotesController(INoteService noteService, ITaskService taskService,
         return Ok(notes.Select(ToDto));
     }
 
-    // GET: api/v1/taskitems/{taskId}/notes/{id}
+    // GET: api/v1/TaskItems/{taskId}/notes/{id}
     [HttpGet("{id}", Name = GetNoteRouteName)]
     public async Task<ActionResult<NoteResponseDto>> Get(int taskId, int id)
     {
@@ -117,7 +117,7 @@ public class NotesController(INoteService noteService, ITaskService taskService,
             return NotFound();
         }
 
-        await _noteService.DeleteNoteAsync(id);
+        await _noteService.DeleteNoteAsync(taskId, id);
         return NoContent();
     }
 

--- a/TaskFlow.Api/Controllers/V1/NotesController.cs
+++ b/TaskFlow.Api/Controllers/V1/NotesController.cs
@@ -1,0 +1,132 @@
+using Asp.Versioning;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Services;
+
+namespace TaskFlow.Api.Controllers.V1;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/taskitems/{taskId}/notes")]
+public class NotesController(INoteService noteService, ITaskService taskService, IValidator<Note> validator) : ControllerBase
+{
+    private const string GetNoteRouteName = "GetNoteV1";
+    private const string ApiVersionString = "1.0";
+    private readonly INoteService _noteService = noteService;
+    private readonly ITaskService _taskService = taskService;
+    private readonly IValidator<Note> _validator = validator;
+
+    // GET: api/v1/taskitems/{taskId}/notes
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<NoteResponseDto>>> GetAll(int taskId)
+    {
+        var task = await _taskService.GetTaskAsync(taskId);
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        var notes = await _noteService.GetNotesForTaskAsync(taskId);
+        return Ok(notes.Select(ToDto));
+    }
+
+    // GET: api/v1/taskitems/{taskId}/notes/{id}
+    [HttpGet("{id}", Name = GetNoteRouteName)]
+    public async Task<ActionResult<NoteResponseDto>> Get(int taskId, int id)
+    {
+        var task = await _taskService.GetTaskAsync(taskId);
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        var note = await _noteService.GetNoteAsync(taskId, id);
+        if (note is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToDto(note));
+    }
+
+    // POST: api/v1/taskitems/{taskId}/notes
+    [HttpPost]
+    public async Task<ActionResult<NoteResponseDto>> Create(int taskId, [FromBody] CreateNoteDto createDto)
+    {
+        var task = await _taskService.GetTaskAsync(taskId);
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        var note = new Note { Content = createDto.Content, TaskItemId = taskId };
+
+        var validationResult = await _validator.ValidateAsync(note);
+        if (!validationResult.IsValid)
+        {
+            return BadRequest(validationResult.Errors);
+        }
+
+        var created = await _noteService.CreateNoteAsync(note);
+        return CreatedAtRoute(GetNoteRouteName, new { version = ApiVersionString, taskId, id = created.Id }, ToDto(created));
+    }
+
+    // PUT: api/v1/taskitems/{taskId}/notes/{id}
+    [HttpPut("{id}")]
+    public async Task<ActionResult<NoteResponseDto>> Update(int taskId, int id, [FromBody] UpdateNoteDto updateDto)
+    {
+        var task = await _taskService.GetTaskAsync(taskId);
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        var existing = await _noteService.GetNoteAsync(taskId, id);
+        if (existing is null)
+        {
+            return NotFound();
+        }
+
+        existing.Content = updateDto.Content;
+
+        var validationResult = await _validator.ValidateAsync(existing);
+        if (!validationResult.IsValid)
+        {
+            return BadRequest(validationResult.Errors);
+        }
+
+        await _noteService.UpdateNoteAsync(existing);
+        return Ok(ToDto(existing));
+    }
+
+    // DELETE: api/v1/taskitems/{taskId}/notes/{id}
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int taskId, int id)
+    {
+        var task = await _taskService.GetTaskAsync(taskId);
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        var existing = await _noteService.GetNoteAsync(taskId, id);
+        if (existing is null)
+        {
+            return NotFound();
+        }
+
+        await _noteService.DeleteNoteAsync(id);
+        return NoContent();
+    }
+
+    private static NoteResponseDto ToDto(Note note) => new()
+    {
+        Id = note.Id,
+        Content = note.Content,
+        TaskItemId = note.TaskItemId,
+        CreatedAt = note.CreatedAt,
+        UpdatedAt = note.UpdatedAt
+    };
+}

--- a/TaskFlow.Api/DTOs/CreateNoteDto.cs
+++ b/TaskFlow.Api/DTOs/CreateNoteDto.cs
@@ -1,0 +1,6 @@
+namespace TaskFlow.Api.DTOs;
+
+public class CreateNoteDto
+{
+    public required string Content { get; set; }
+}

--- a/TaskFlow.Api/DTOs/NoteResponseDto.cs
+++ b/TaskFlow.Api/DTOs/NoteResponseDto.cs
@@ -1,0 +1,10 @@
+namespace TaskFlow.Api.DTOs;
+
+public class NoteResponseDto
+{
+    public int Id { get; set; }
+    public required string Content { get; set; }
+    public int TaskItemId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/TaskFlow.Api/DTOs/UpdateNoteDto.cs
+++ b/TaskFlow.Api/DTOs/UpdateNoteDto.cs
@@ -1,0 +1,6 @@
+namespace TaskFlow.Api.DTOs;
+
+public class UpdateNoteDto
+{
+    public required string Content { get; set; }
+}

--- a/TaskFlow.Api/Data/TaskDbContext.cs
+++ b/TaskFlow.Api/Data/TaskDbContext.cs
@@ -6,6 +6,7 @@ namespace TaskFlow.Api.Data;
 public class TaskDbContext(DbContextOptions<TaskDbContext> options) : DbContext(options)
 {
     public DbSet<TaskItem> TaskItems => Set<TaskItem>();
+    public DbSet<Note> Notes => Set<Note>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -15,6 +16,14 @@ public class TaskDbContext(DbContextOptions<TaskDbContext> options) : DbContext(
         {
             entity.Property(t => t.Status)
                   .HasConversion<int>();
+        });
+
+        modelBuilder.Entity<Note>(entity =>
+        {
+            entity.HasOne(n => n.TaskItem)
+                  .WithMany(t => t.Notes)
+                  .HasForeignKey(n => n.TaskItemId)
+                  .OnDelete(DeleteBehavior.Cascade);
         });
     }
 }

--- a/TaskFlow.Api/Extensions/ApplicationServiceExtensions.cs
+++ b/TaskFlow.Api/Extensions/ApplicationServiceExtensions.cs
@@ -16,6 +16,7 @@ public static class ApplicationServiceExtensions
     {
         // Register application services
         services.AddScoped<ITaskService, TaskService>();
+        services.AddScoped<INoteService, NoteService>();
 
         return services;
     }

--- a/TaskFlow.Api/Extensions/PersistenceServiceExtensions.cs
+++ b/TaskFlow.Api/Extensions/PersistenceServiceExtensions.cs
@@ -29,6 +29,7 @@ public static class PersistenceServiceExtensions
 
         // Register repositories
         services.AddScoped<ITaskRepository, TaskRepository>();
+        services.AddScoped<INoteRepository, NoteRepository>();
 
         return services;
     }

--- a/TaskFlow.Api/Migrations/20260418035204_AddNotesEntity.Designer.cs
+++ b/TaskFlow.Api/Migrations/20260418035204_AddNotesEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TaskFlow.Api.Data;
 
@@ -10,9 +11,11 @@ using TaskFlow.Api.Data;
 namespace TaskFlow.Api.Migrations
 {
     [DbContext(typeof(TaskDbContext))]
-    partial class TaskDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418035204_AddNotesEntity")]
+    partial class AddNotesEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/TaskFlow.Api/Migrations/20260418035204_AddNotesEntity.cs
+++ b/TaskFlow.Api/Migrations/20260418035204_AddNotesEntity.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TaskFlow.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotesEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Notes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    TaskItemId = table.Column<int>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Notes_TaskItems_TaskItemId",
+                        column: x => x.TaskItemId,
+                        principalTable: "TaskItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notes_TaskItemId",
+                table: "Notes",
+                column: "TaskItemId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Notes");
+        }
+    }
+}

--- a/TaskFlow.Api/Models/Note.cs
+++ b/TaskFlow.Api/Models/Note.cs
@@ -1,0 +1,11 @@
+namespace TaskFlow.Api.Models;
+
+public class Note
+{
+    public int Id { get; set; }
+    public required string Content { get; set; }
+    public int TaskItemId { get; set; }
+    public TaskItem TaskItem { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/TaskFlow.Api/Models/TaskItem.cs
+++ b/TaskFlow.Api/Models/TaskItem.cs
@@ -9,4 +9,5 @@ public class TaskItem
     public Priority Priority { get; set; } = Priority.Low;
     public Status Status { get; set; } = Status.Draft;
     public DateTime? DueDate { get; set; }
+    public ICollection<Note> Notes { get; set; } = [];
 }

--- a/TaskFlow.Api/Repositories/INoteRepository.cs
+++ b/TaskFlow.Api/Repositories/INoteRepository.cs
@@ -1,0 +1,12 @@
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Repositories;
+
+public interface INoteRepository
+{
+    Task<IEnumerable<Note>> GetAllByTaskIdAsync(int taskId);
+    Task<Note?> GetByIdAsync(int taskId, int noteId);
+    Task<Note> AddAsync(Note note);
+    Task UpdateAsync(Note note);
+    Task DeleteAsync(int id);
+}

--- a/TaskFlow.Api/Repositories/INoteRepository.cs
+++ b/TaskFlow.Api/Repositories/INoteRepository.cs
@@ -8,5 +8,5 @@ public interface INoteRepository
     Task<Note?> GetByIdAsync(int taskId, int noteId);
     Task<Note> AddAsync(Note note);
     Task UpdateAsync(Note note);
-    Task DeleteAsync(int id);
+    Task DeleteAsync(int taskId, int noteId);
 }

--- a/TaskFlow.Api/Repositories/NoteRepository.cs
+++ b/TaskFlow.Api/Repositories/NoteRepository.cs
@@ -29,9 +29,9 @@ public class NoteRepository(TaskDbContext context) : INoteRepository
         await _context.SaveChangesAsync();
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task DeleteAsync(int taskId, int noteId)
     {
-        var note = await _context.Notes.FindAsync(id);
+        var note = await _context.Notes.FirstOrDefaultAsync(n => n.Id == noteId && n.TaskItemId == taskId);
         if (note is null)
         {
             return;

--- a/TaskFlow.Api/Repositories/NoteRepository.cs
+++ b/TaskFlow.Api/Repositories/NoteRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using TaskFlow.Api.Data;
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Repositories;
+
+public class NoteRepository(TaskDbContext context) : INoteRepository
+{
+    private readonly TaskDbContext _context = context;
+
+    public async Task<IEnumerable<Note>> GetAllByTaskIdAsync(int taskId) =>
+        await _context.Notes.Where(n => n.TaskItemId == taskId).ToListAsync();
+
+    public async Task<Note?> GetByIdAsync(int taskId, int noteId) =>
+        await _context.Notes.FirstOrDefaultAsync(n => n.Id == noteId && n.TaskItemId == taskId);
+
+    public async Task<Note> AddAsync(Note note)
+    {
+        note.CreatedAt = DateTime.UtcNow;
+        _context.Notes.Add(note);
+        await _context.SaveChangesAsync();
+        return note;
+    }
+
+    public async Task UpdateAsync(Note note)
+    {
+        note.UpdatedAt = DateTime.UtcNow;
+        _context.Notes.Update(note);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var note = await _context.Notes.FindAsync(id);
+        if (note is null)
+        {
+            return;
+        }
+
+        _context.Notes.Remove(note);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/TaskFlow.Api/Services/INoteService.cs
+++ b/TaskFlow.Api/Services/INoteService.cs
@@ -8,5 +8,5 @@ public interface INoteService
     Task<Note?> GetNoteAsync(int taskId, int noteId);
     Task<Note> CreateNoteAsync(Note note);
     Task UpdateNoteAsync(Note note);
-    Task DeleteNoteAsync(int id);
+    Task DeleteNoteAsync(int taskId, int noteId);
 }

--- a/TaskFlow.Api/Services/INoteService.cs
+++ b/TaskFlow.Api/Services/INoteService.cs
@@ -1,0 +1,12 @@
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Services;
+
+public interface INoteService
+{
+    Task<IEnumerable<Note>> GetNotesForTaskAsync(int taskId);
+    Task<Note?> GetNoteAsync(int taskId, int noteId);
+    Task<Note> CreateNoteAsync(Note note);
+    Task UpdateNoteAsync(Note note);
+    Task DeleteNoteAsync(int id);
+}

--- a/TaskFlow.Api/Services/NoteService.cs
+++ b/TaskFlow.Api/Services/NoteService.cs
@@ -1,0 +1,24 @@
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repositories;
+
+namespace TaskFlow.Api.Services;
+
+public class NoteService(INoteRepository repo) : INoteService
+{
+    private readonly INoteRepository _repo = repo;
+
+    public async Task<IEnumerable<Note>> GetNotesForTaskAsync(int taskId) =>
+        await _repo.GetAllByTaskIdAsync(taskId);
+
+    public async Task<Note?> GetNoteAsync(int taskId, int noteId) =>
+        await _repo.GetByIdAsync(taskId, noteId);
+
+    public async Task<Note> CreateNoteAsync(Note note) =>
+        await _repo.AddAsync(note);
+
+    public async Task UpdateNoteAsync(Note note) =>
+        await _repo.UpdateAsync(note);
+
+    public async Task DeleteNoteAsync(int id) =>
+        await _repo.DeleteAsync(id);
+}

--- a/TaskFlow.Api/Services/NoteService.cs
+++ b/TaskFlow.Api/Services/NoteService.cs
@@ -19,6 +19,6 @@ public class NoteService(INoteRepository repo) : INoteService
     public async Task UpdateNoteAsync(Note note) =>
         await _repo.UpdateAsync(note);
 
-    public async Task DeleteNoteAsync(int id) =>
-        await _repo.DeleteAsync(id);
+    public async Task DeleteNoteAsync(int taskId, int noteId) =>
+        await _repo.DeleteAsync(taskId, noteId);
 }

--- a/TaskFlow.Api/Validators/NoteValidator.cs
+++ b/TaskFlow.Api/Validators/NoteValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Validators;
+
+public class NoteValidator : AbstractValidator<Note>
+{
+    public NoteValidator()
+    {
+        RuleFor(n => n.Content)
+            .NotEmpty().WithMessage("Content is required.")
+            .MaximumLength(2000).WithMessage("Content must not exceed 2000 characters.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Note` entity linked to `TaskItem` via FK with cascade delete
- Nested REST endpoints: `api/v1/taskitems/{taskId}/notes` — all operations scope to the parent task, returning 404 if the task doesn't exist
- `NoteValidator` enforces Content is required and max 2000 characters
- EF Core migration adds `Notes` table with FK constraint
- Fixes `.gitignore` `data/` pattern anchored to `/data/` to prevent case-insensitive match on `TaskFlow.Api/Data/` on Windows

## Endpoints

| Method | Route | Description |
|--------|-------|-------------|
| GET | `api/v1/taskitems/{taskId}/notes` | List notes for a task |
| GET | `api/v1/taskitems/{taskId}/notes/{id}` | Get a single note |
| POST | `api/v1/taskitems/{taskId}/notes` | Create a note |
| PUT | `api/v1/taskitems/{taskId}/notes/{id}` | Update a note |
| DELETE | `api/v1/taskitems/{taskId}/notes/{id}` | Delete a note |

## Test plan

- [x] `dotnet test` passes (134 tests across all layers)
- [x] `docker compose up -d` — migrations run on startup, Notes table created
- [x] POST a note to an existing task → 201 with Location header
- [x] GET notes for a task → filtered list for that task only
- [x] POST a note to a non-existent task → 404
- [x] DELETE a task → its notes are cascade-deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)