### PR TITLE
Always add console logging as fallback alongside Seq/OTLP

### DIFF
--- a/TaskFlow.Api/Extensions/OpenTelemetryServiceExtensions.cs
+++ b/TaskFlow.Api/Extensions/OpenTelemetryServiceExtensions.cs
@@ -67,8 +67,8 @@ public static class OpenTelemetryServiceExtensions
     }
 
     /// <summary>
-    /// Clears default logging providers and routes logs to Seq via OTLP.
-    /// A console provider is added when running in the Development environment.
+    /// Clears default logging providers and routes logs to both the console and Seq via OTLP.
+    /// Console acts as a fallback so logs are captured in container stdout if Seq is unreachable.
     /// </summary>
     /// <param name="logging">The logging builder</param>
     /// <param name="configuration">Application configuration used to read endpoint and API key header</param>
@@ -111,10 +111,7 @@ public static class OpenTelemetryServiceExtensions
             });
         });
 
-        if (environment.IsDevelopment())
-        {
-            logging.AddConsole();
-        }
+        logging.AddConsole();
 
         return logging;
     }


### PR DESCRIPTION
## Summary

- Console logging was previously only enabled in the Development environment
- Now enabled in all environments so logs are captured in container stdout if Seq is unavailable or not yet ready at startup
- Log levels are still controlled via `appsettings.json` per environment

## Why

If Seq is slow to start or temporarily unreachable, logs emitted during that window are silently dropped. Container orchestrators (Docker, Kubernetes) capture stdout/stderr independently of Seq, so console output acts as a reliable fallback.

## Test plan

- [x] `dotnet test` passes
- [x] `docker compose up -d` — API logs visible in `docker compose logs taskflow-api`
- [x] Logs also appear in Seq at http://localhost:5380

🤖 Generated with [Claude Code](https://claude.com/claude-code)