### PR TITLE
feat: add top nav bar linking journal and tasks pages

### DIFF
--- a/TaskFlow.Web/src/App.tsx
+++ b/TaskFlow.Web/src/App.tsx
@@ -2,15 +2,18 @@ import { Navigate, Routes, Route } from 'react-router-dom'
 import { TasksPage } from '@/pages/TasksPage'
 import { TaskDetailPage } from '@/pages/TaskDetailPage'
 import { JournalPage } from '@/pages/JournalPage'
+import { Layout } from '@/components/Layout'
 import { todayUrlDate } from '@/lib/journal-utils'
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Navigate to={`/journal/${todayUrlDate()}`} replace />} />
-      <Route path="/journal/:date" element={<JournalPage />} />
-      <Route path="/tasks" element={<TasksPage />} />
-      <Route path="/tasks/:id" element={<TaskDetailPage />} />
+      <Route element={<Layout />}>
+        <Route path="/journal/:date" element={<JournalPage />} />
+        <Route path="/tasks" element={<TasksPage />} />
+        <Route path="/tasks/:id" element={<TaskDetailPage />} />
+      </Route>
     </Routes>
   )
 }

--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom'
+import { Nav } from '@/components/Nav'
+
+export function Layout() {
+  return (
+    <>
+      <Nav />
+      <Outlet />
+    </>
+  )
+}

--- a/TaskFlow.Web/src/components/Nav.test.tsx
+++ b/TaskFlow.Web/src/components/Nav.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { Nav } from './Nav'
+
+function renderNav(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Nav />
+    </MemoryRouter>
+  )
+}
+
+describe('Nav', () => {
+  it('renders Journal and Tasks links', () => {
+    renderNav('/')
+    expect(screen.getByRole('link', { name: /journal/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /tasks/i })).toBeInTheDocument()
+  })
+
+  it('has an accessible name on the nav landmark', () => {
+    renderNav('/')
+    expect(screen.getByRole('navigation', { name: /primary navigation/i })).toBeInTheDocument()
+  })
+
+  it('marks Journal link as active on a journal route', () => {
+    renderNav('/journal/05-14-2026')
+    const journalLink = screen.getByRole('link', { name: /journal/i })
+    const tasksLink = screen.getByRole('link', { name: /tasks/i })
+    expect(journalLink.className).toContain('bg-blue-600')
+    expect(tasksLink.className).not.toContain('bg-blue-600')
+  })
+
+  it('marks Tasks link as active on the tasks route', () => {
+    renderNav('/tasks')
+    const journalLink = screen.getByRole('link', { name: /journal/i })
+    const tasksLink = screen.getByRole('link', { name: /tasks/i })
+    expect(tasksLink.className).toContain('bg-blue-600')
+    expect(journalLink.className).not.toContain('bg-blue-600')
+  })
+
+  it('marks Tasks link as active on a task detail route', () => {
+    renderNav('/tasks/42')
+    const tasksLink = screen.getByRole('link', { name: /tasks/i })
+    expect(tasksLink.className).toContain('bg-blue-600')
+  })
+
+  it('Journal link points to today\'s journal date', () => {
+    renderNav('/')
+    const journalLink = screen.getByRole('link', { name: /journal/i })
+    expect(journalLink.getAttribute('href')).toMatch(/^\/journal\/\d{2}-\d{2}-\d{4}$/)
+  })
+
+  it('Tasks link points to /tasks', () => {
+    renderNav('/')
+    expect(screen.getByRole('link', { name: /tasks/i })).toHaveAttribute('href', '/tasks')
+  })
+})

--- a/TaskFlow.Web/src/components/Nav.tsx
+++ b/TaskFlow.Web/src/components/Nav.tsx
@@ -11,7 +11,7 @@ export function Nav() {
   const inactive = 'text-slate-600 hover:text-slate-900 hover:bg-slate-100'
 
   return (
-    <nav className="flex gap-1 px-4 py-2 border-b border-slate-200 bg-white">
+    <nav aria-label="Primary navigation" className="flex gap-1 px-4 py-2 border-b border-slate-200 bg-white">
       <Link to={`/journal/${todayUrlDate()}`} className={`${base} ${isJournal ? active : inactive}`}>
         Journal
       </Link>

--- a/TaskFlow.Web/src/components/Nav.tsx
+++ b/TaskFlow.Web/src/components/Nav.tsx
@@ -1,0 +1,23 @@
+import { Link, useLocation } from 'react-router-dom'
+import { todayUrlDate } from '@/lib/journal-utils'
+
+export function Nav() {
+  const { pathname } = useLocation()
+  const isJournal = pathname.startsWith('/journal')
+  const isTasks = pathname.startsWith('/tasks')
+
+  const base = 'px-3 py-1.5 rounded text-sm font-medium transition-colors'
+  const active = 'bg-blue-600 text-white'
+  const inactive = 'text-slate-600 hover:text-slate-900 hover:bg-slate-100'
+
+  return (
+    <nav className="flex gap-1 px-4 py-2 border-b border-slate-200 bg-white">
+      <Link to={`/journal/${todayUrlDate()}`} className={`${base} ${isJournal ? active : inactive}`}>
+        Journal
+      </Link>
+      <Link to="/tasks" className={`${base} ${isTasks ? active : inactive}`}>
+        Tasks
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a `Nav` component with **Journal** and **Tasks** links, with active-state highlighting based on the current route
- Adds a `Layout` wrapper component that renders `<Nav />` above `<Outlet />` so all pages share consistent navigation
- Updates `App.tsx` to wrap all content routes in `<Layout />` (journal, tasks, task detail)

## Test plan

- [ ] Visit `/` — redirects to today's journal with nav bar visible and **Journal** link active
- [ ] Click **Tasks** in nav — navigates to `/tasks` with **Tasks** link active
- [ ] Click **Journal** in nav — returns to today's journal with **Journal** link active
- [ ] Navigate to a task detail page (`/tasks/:id`) — nav bar still present
- [ ] Navigate to a past journal date — **Journal** link remains active (path-prefix match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)