### PR TITLE
feat: unify site theme with journal design system; dark mode default

### DIFF
--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -26,7 +26,7 @@ export function Layout() {
     try {
       const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
       localStorage.setItem(PREFS_KEY, JSON.stringify({ ...prefs, dark: isDark }))
-    } catch {}
+    } catch { /* localStorage unavailable */ }
   }, [isDark])
 
   return (

--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -1,11 +1,38 @@
+import { useState, useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Nav } from '@/components/Nav'
 
+export interface AppContext {
+  isDark: boolean
+  setIsDark: (v: boolean | ((prev: boolean) => boolean)) => void
+}
+
+const PREFS_KEY = 'taskflow_journal_prefs_v1'
+
+function loadDark(): boolean {
+  try {
+    const saved = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}').dark
+    return saved != null ? saved : true
+  } catch {
+    return true
+  }
+}
+
 export function Layout() {
+  const [isDark, setIsDark] = useState<boolean>(loadDark)
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('is-dark', isDark)
+    try {
+      const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
+      localStorage.setItem(PREFS_KEY, JSON.stringify({ ...prefs, dark: isDark }))
+    } catch {}
+  }, [isDark])
+
   return (
     <>
       <Nav />
-      <Outlet />
+      <Outlet context={{ isDark, setIsDark } satisfies AppContext} />
     </>
   )
 }

--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -1,21 +1,16 @@
 import { useState, useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Nav } from '@/components/Nav'
+import { loadPrefs, savePrefs } from '@/lib/prefs'
 
 export interface AppContext {
   isDark: boolean
   setIsDark: (v: boolean | ((prev: boolean) => boolean)) => void
 }
 
-const PREFS_KEY = 'taskflow_journal_prefs_v1'
-
 function loadDark(): boolean {
-  try {
-    const saved = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}').dark
-    return saved != null ? saved : true
-  } catch {
-    return true
-  }
+  const saved = loadPrefs().dark
+  return typeof saved === 'boolean' ? saved : true
 }
 
 export function Layout() {
@@ -23,10 +18,7 @@ export function Layout() {
 
   useEffect(() => {
     document.documentElement.classList.toggle('is-dark', isDark)
-    try {
-      const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
-      localStorage.setItem(PREFS_KEY, JSON.stringify({ ...prefs, dark: isDark }))
-    } catch { /* localStorage unavailable */ }
+    savePrefs({ dark: isDark })
   }, [isDark])
 
   return (

--- a/TaskFlow.Web/src/components/Nav.test.tsx
+++ b/TaskFlow.Web/src/components/Nav.test.tsx
@@ -27,22 +27,22 @@ describe('Nav', () => {
     renderNav('/journal/05-14-2026')
     const journalLink = screen.getByRole('link', { name: /journal/i })
     const tasksLink = screen.getByRole('link', { name: /tasks/i })
-    expect(journalLink.className).toContain('bg-blue-600')
-    expect(tasksLink.className).not.toContain('bg-blue-600')
+    expect(journalLink.className).toContain('is-active')
+    expect(tasksLink.className).not.toContain('is-active')
   })
 
   it('marks Tasks link as active on the tasks route', () => {
     renderNav('/tasks')
     const journalLink = screen.getByRole('link', { name: /journal/i })
     const tasksLink = screen.getByRole('link', { name: /tasks/i })
-    expect(tasksLink.className).toContain('bg-blue-600')
-    expect(journalLink.className).not.toContain('bg-blue-600')
+    expect(tasksLink.className).toContain('is-active')
+    expect(journalLink.className).not.toContain('is-active')
   })
 
   it('marks Tasks link as active on a task detail route', () => {
     renderNav('/tasks/42')
     const tasksLink = screen.getByRole('link', { name: /tasks/i })
-    expect(tasksLink.className).toContain('bg-blue-600')
+    expect(tasksLink.className).toContain('is-active')
   })
 
   it('Journal link points to today\'s journal date', () => {

--- a/TaskFlow.Web/src/components/Nav.tsx
+++ b/TaskFlow.Web/src/components/Nav.tsx
@@ -6,16 +6,18 @@ export function Nav() {
   const isJournal = pathname.startsWith('/journal')
   const isTasks = pathname.startsWith('/tasks')
 
-  const base = 'px-3 py-1.5 rounded text-sm font-medium transition-colors'
-  const active = 'bg-blue-600 text-white'
-  const inactive = 'text-slate-600 hover:text-slate-900 hover:bg-slate-100'
-
   return (
-    <nav className="flex gap-1 px-4 py-2 border-b border-slate-200 bg-white">
-      <Link to={`/journal/${todayUrlDate()}`} className={`${base} ${isJournal ? active : inactive}`}>
+    <nav className="app-nav">
+      <Link
+        to={`/journal/${todayUrlDate()}`}
+        className={`app-nav-link${isJournal ? ' is-active' : ''}`}
+      >
         Journal
       </Link>
-      <Link to="/tasks" className={`${base} ${isTasks ? active : inactive}`}>
+      <Link
+        to="/tasks"
+        className={`app-nav-link${isTasks ? ' is-active' : ''}`}
+      >
         Tasks
       </Link>
     </nav>

--- a/TaskFlow.Web/src/components/NoteCard.tsx
+++ b/TaskFlow.Web/src/components/NoteCard.tsx
@@ -9,25 +9,13 @@ interface Props {
 
 export function NoteCard({ note, onEdit, onDelete }: Props) {
   return (
-    <div className="rounded-lg border bg-white p-3 flex flex-col gap-2">
-      <p className="text-sm text-slate-800 whitespace-pre-wrap">{note.content}</p>
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-slate-400">{formatDate(note.createdAt)}</span>
-        <div className="flex gap-1">
-          <button
-            aria-label="Edit"
-            onClick={() => onEdit(note)}
-            className="rounded px-2 py-1 text-xs text-slate-600 hover:bg-slate-100"
-          >
-            Edit
-          </button>
-          <button
-            aria-label="Delete"
-            onClick={() => onDelete(note)}
-            className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
-          >
-            Delete
-          </button>
+    <div className="t-note-card">
+      <p className="t-note-content">{note.content}</p>
+      <div className="t-note-footer">
+        <span className="t-note-date">{formatDate(note.createdAt)}</span>
+        <div className="t-note-actions">
+          <button className="t-btn" aria-label="Edit" onClick={() => onEdit(note)}>Edit</button>
+          <button className="t-btn-danger" aria-label="Delete" onClick={() => onDelete(note)}>Delete</button>
         </div>
       </div>
     </div>

--- a/TaskFlow.Web/src/components/NoteForm.tsx
+++ b/TaskFlow.Web/src/components/NoteForm.tsx
@@ -16,32 +16,21 @@ export function NoteForm({ note, onSubmit, onCancel }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1">
-        <label htmlFor="content" className="text-sm font-medium text-slate-700">Content</label>
+    <form onSubmit={handleSubmit} className="t-form">
+      <div className="t-field">
+        <label htmlFor="content" className="t-label">Content</label>
         <textarea
           id="content"
+          className="t-input"
           value={content}
           onChange={e => setContent(e.target.value)}
           rows={4}
           required
-          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
         />
       </div>
-      <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded px-4 py-2 text-sm text-slate-600 hover:bg-slate-100"
-        >
-          Cancel
-        </button>
-        <button
-          type="submit"
-          className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
-        >
-          Save
-        </button>
+      <div className="t-form-actions">
+        <button type="button" className="t-btn" onClick={onCancel}>Cancel</button>
+        <button type="submit" className="t-btn-primary">Save</button>
       </div>
     </form>
   )

--- a/TaskFlow.Web/src/components/TaskCard.tsx
+++ b/TaskFlow.Web/src/components/TaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { cn, formatDate } from '@/lib/utils'
+import { formatDate } from '@/lib/utils'
 import type { TaskItemResponseDto } from '@/api/client/types.gen'
 
 interface Props {
@@ -8,58 +8,27 @@ interface Props {
   onDelete: (task: TaskItemResponseDto) => void
 }
 
-const priorityClass: Record<string, string> = {
-  low: 'bg-slate-100 text-slate-700',
-  medium: 'bg-yellow-100 text-yellow-800',
-  high: 'bg-red-100 text-red-700',
-}
-
-const statusClass: Record<string, string> = {
-  draft: 'bg-slate-100 text-slate-700',
-  todo: 'bg-blue-100 text-blue-700',
-  completed: 'bg-green-100 text-green-700',
-}
-
 export function TaskCard({ task, onEdit, onDelete }: Props) {
   const status = String(task.status ?? 'draft').toLowerCase()
   const priority = String(task.priority ?? 'low').toLowerCase()
 
   return (
-    <div className="rounded-lg border bg-white p-4 shadow-sm flex flex-col gap-2">
-      <div className="flex items-start justify-between gap-2">
-        <Link
-          to={`/tasks/${task.id}`}
-          className="font-semibold text-slate-900 hover:underline"
-        >
+    <div className="t-card">
+      <div className="t-card-row">
+        <Link to={`/tasks/${task.id}`} className="t-task-link">
           {task.title}
         </Link>
-        <div className="flex gap-1 shrink-0">
-          <button
-            aria-label="Edit"
-            onClick={() => onEdit(task)}
-            className="rounded px-2 py-1 text-xs text-slate-600 hover:bg-slate-100"
-          >
-            Edit
-          </button>
-          <button
-            aria-label="Delete"
-            onClick={() => onDelete(task)}
-            className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
-          >
-            Delete
-          </button>
+        <div className="t-card-actions">
+          <button className="t-btn" aria-label="Edit" onClick={() => onEdit(task)}>Edit</button>
+          <button className="t-btn-danger" aria-label="Delete" onClick={() => onDelete(task)}>Delete</button>
         </div>
       </div>
-      <div className="flex gap-2 flex-wrap">
-        <span className={cn('rounded-full px-2 py-0.5 text-xs font-medium', statusClass[status] ?? statusClass.draft)}>
-          {status}
-        </span>
-        <span className={cn('rounded-full px-2 py-0.5 text-xs font-medium', priorityClass[priority] ?? priorityClass.low)}>
-          {priority}
-        </span>
+      <div className="t-badges">
+        <span className={`t-badge t-badge-${status}`}>{status}</span>
+        <span className={`t-badge t-badge-${priority}`}>{priority}</span>
       </div>
       {task.dueDate && (
-        <p className="text-xs text-slate-500">Due {formatDate(task.dueDate)}</p>
+        <span className="t-card-meta">Due {formatDate(task.dueDate)}</span>
       )}
     </div>
   )

--- a/TaskFlow.Web/src/components/TaskForm.tsx
+++ b/TaskFlow.Web/src/components/TaskForm.tsx
@@ -27,79 +27,46 @@ export function TaskForm({ task, onSubmit, onCancel }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <label htmlFor="title" className="text-sm font-medium text-slate-700">Title</label>
-        <input
-          id="title"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          required
-          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-        />
+    <form onSubmit={handleSubmit} className="t-form">
+      <div className="t-field">
+        <label htmlFor="title" className="t-label">Title</label>
+        <input id="title" className="t-input" value={title} onChange={e => setTitle(e.target.value)} required />
       </div>
-      <div className="flex flex-col gap-1">
-        <label htmlFor="description" className="text-sm font-medium text-slate-700">Description</label>
+      <div className="t-field">
+        <label htmlFor="description" className="t-label">Description</label>
         <textarea
           id="description"
+          className="t-input"
           value={description ?? ''}
           onChange={e => setDescription(e.target.value)}
           rows={3}
-          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
         />
       </div>
-      <div className="flex gap-4">
-        <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor="status" className="text-sm font-medium text-slate-700">Status</label>
-          <select
-            id="status"
-            value={status}
-            onChange={e => setStatus(e.target.value)}
-            className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-          >
+      <div className="t-form-row">
+        <div className="t-field">
+          <label htmlFor="status" className="t-label">Status</label>
+          <select id="status" className="t-input" value={status} onChange={e => setStatus(e.target.value)}>
             <option value="draft">Draft</option>
             <option value="todo">Todo</option>
             <option value="completed">Completed</option>
           </select>
         </div>
-        <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor="priority" className="text-sm font-medium text-slate-700">Priority</label>
-          <select
-            id="priority"
-            value={priority}
-            onChange={e => setPriority(e.target.value)}
-            className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-          >
+        <div className="t-field">
+          <label htmlFor="priority" className="t-label">Priority</label>
+          <select id="priority" className="t-input" value={priority} onChange={e => setPriority(e.target.value)}>
             <option value="low">Low</option>
             <option value="medium">Medium</option>
             <option value="high">High</option>
           </select>
         </div>
       </div>
-      <div className="flex flex-col gap-1">
-        <label htmlFor="dueDate" className="text-sm font-medium text-slate-700">Due Date</label>
-        <input
-          id="dueDate"
-          type="date"
-          value={dueDate}
-          onChange={e => setDueDate(e.target.value)}
-          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-        />
+      <div className="t-field">
+        <label htmlFor="dueDate" className="t-label">Due Date</label>
+        <input id="dueDate" type="date" className="t-input" value={dueDate} onChange={e => setDueDate(e.target.value)} />
       </div>
-      <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded px-4 py-2 text-sm text-slate-600 hover:bg-slate-100"
-        >
-          Cancel
-        </button>
-        <button
-          type="submit"
-          className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
-        >
-          Save
-        </button>
+      <div className="t-form-actions">
+        <button type="button" className="t-btn" onClick={onCancel}>Cancel</button>
+        <button type="submit" className="t-btn-primary">Save</button>
       </div>
     </form>
   )

--- a/TaskFlow.Web/src/index.css
+++ b/TaskFlow.Web/src/index.css
@@ -19,6 +19,10 @@
   --hover-soft: #eef2f7;
   --danger-bg: #fee2e2;
   --danger-ink: #b91c1c;
+  --success-bg: color-mix(in oklab, #22c55e 15%, transparent);
+  --success-ink: #15803d;
+  --warn-bg: color-mix(in oklab, #f59e0b 15%, transparent);
+  --warn-ink: #b45309;
   --shadow-sm: 0 1px 2px rgba(15,23,42,.04), 0 1px 1px rgba(15,23,42,.03);
   --shadow-md: 0 1px 2px rgba(15,23,42,.04), 0 8px 24px rgba(15,23,42,.06);
   --radius: 12px;
@@ -42,6 +46,10 @@ html.is-dark {
   --hover-soft: #1a2438;
   --danger-bg: #3a1316;
   --danger-ink: #fca5a5;
+  --success-bg: color-mix(in oklab, #22c55e 18%, #131b2c);
+  --success-ink: #4ade80;
+  --warn-bg: color-mix(in oklab, #f59e0b 18%, #131b2c);
+  --warn-ink: #fbbf24;
   --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
   --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
   color-scheme: dark;

--- a/TaskFlow.Web/src/index.css
+++ b/TaskFlow.Web/src/index.css
@@ -1,61 +1,91 @@
 @import "tailwindcss";
 
+/* ─── Global design tokens ─────────────────────────────────────────────────── */
+
+:root {
+  --bg: #f6f7f9;
+  --paper: #ffffff;
+  --paper-2: #fdfdfb;
+  --ink: #0f172a;
+  --ink-2: #334155;
+  --muted: #64748b;
+  --muted-2: #94a3b8;
+  --line: #e2e8f0;
+  --line-2: #cbd5e1;
+  --line-soft: #eef2f7;
+  --accent: #2563eb;
+  --accent-soft: color-mix(in oklab, var(--accent) 10%, white);
+  --accent-ink: color-mix(in oklab, var(--accent) 70%, #0f172a);
+  --hover-soft: #eef2f7;
+  --danger-bg: #fee2e2;
+  --danger-ink: #b91c1c;
+  --shadow-sm: 0 1px 2px rgba(15,23,42,.04), 0 1px 1px rgba(15,23,42,.03);
+  --shadow-md: 0 1px 2px rgba(15,23,42,.04), 0 8px 24px rgba(15,23,42,.06);
+  --radius: 12px;
+  --radius-sm: 8px;
+  color-scheme: light;
+}
+
+html.is-dark {
+  --bg: #0b1220;
+  --paper: #131b2c;
+  --paper-2: #161f33;
+  --ink: #e8edf6;
+  --ink-2: #c2cbdc;
+  --muted: #8b97ad;
+  --muted-2: #5b6781;
+  --line: #1f2a40;
+  --line-2: #2b3853;
+  --line-soft: #19233a;
+  --accent-soft: color-mix(in oklab, var(--accent) 22%, #131b2c);
+  --accent-ink: color-mix(in oklab, var(--accent) 35%, #e8edf6);
+  --hover-soft: #1a2438;
+  --danger-bg: #3a1316;
+  --danger-ink: #fca5a5;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
 @layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.5rem;
-  }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
-  }
-
-  * {
-    border-color: hsl(var(--border));
-  }
+  * { border-color: var(--line); }
 
   body {
     margin: 0;
-    background-color: hsl(var(--background));
-    color: hsl(var(--foreground));
-    font-family: system-ui, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--bg);
+    color: var(--ink);
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+}
+
+/* ─── App-wide nav ─────────────────────────────────────────────────────────── */
+
+.app-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+  box-shadow: var(--shadow-sm);
+}
+
+.app-nav-link {
+  padding: 5px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  text-decoration: none;
+  transition: background .12s, color .12s;
+}
+.app-nav-link:hover {
+  background: var(--hover-soft);
+  color: var(--ink);
+}
+.app-nav-link.is-active {
+  background: var(--accent);
+  color: #fff;
 }

--- a/TaskFlow.Web/src/journal.css
+++ b/TaskFlow.Web/src/journal.css
@@ -3,26 +3,6 @@
    All rules are scoped under .journal-page to avoid conflicts with Tailwind. */
 
 .journal-page {
-  --bg: #f6f7f9;
-  --paper: #ffffff;
-  --paper-2: #fdfdfb;
-  --ink: #0f172a;
-  --ink-2: #334155;
-  --muted: #64748b;
-  --muted-2: #94a3b8;
-  --line: #e2e8f0;
-  --line-2: #cbd5e1;
-  --line-soft: #eef2f7;
-  --accent: #2563eb;
-  --accent-soft: color-mix(in oklab, var(--accent) 10%, white);
-  --accent-ink: color-mix(in oklab, var(--accent) 70%, #0f172a);
-  --hover-soft: #eef2f7;
-  --danger-bg: #fee2e2;
-  --danger-ink: #b91c1c;
-  --shadow-sm: 0 1px 2px rgba(15,23,42,.04), 0 1px 1px rgba(15,23,42,.03);
-  --shadow-md: 0 1px 2px rgba(15,23,42,.04), 0 8px 24px rgba(15,23,42,.06);
-  --radius: 12px;
-  --radius-sm: 8px;
   --den: 1;
   color-scheme: light;
 

--- a/TaskFlow.Web/src/journal.css
+++ b/TaskFlow.Web/src/journal.css
@@ -17,23 +17,6 @@
 }
 
 .journal-page.is-dark {
-  --bg: #0b1220;
-  --paper: #131b2c;
-  --paper-2: #161f33;
-  --ink: #e8edf6;
-  --ink-2: #c2cbdc;
-  --muted: #8b97ad;
-  --muted-2: #5b6781;
-  --line: #1f2a40;
-  --line-2: #2b3853;
-  --line-soft: #19233a;
-  --accent-soft: color-mix(in oklab, var(--accent) 22%, #131b2c);
-  --accent-ink: color-mix(in oklab, var(--accent) 35%, #e8edf6);
-  --hover-soft: #1a2438;
-  --danger-bg: #3a1316;
-  --danger-ink: #fca5a5;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
-  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
   color-scheme: dark;
 }
 

--- a/TaskFlow.Web/src/lib/prefs.ts
+++ b/TaskFlow.Web/src/lib/prefs.ts
@@ -1,6 +1,7 @@
 export const PREFS_KEY = 'taskflow_journal_prefs_v1'
 
-export function loadPrefs(): Record<string, unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function loadPrefs(): Record<string, any> {
   try {
     return JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
   } catch {

--- a/TaskFlow.Web/src/lib/prefs.ts
+++ b/TaskFlow.Web/src/lib/prefs.ts
@@ -1,0 +1,16 @@
+export const PREFS_KEY = 'taskflow_journal_prefs_v1'
+
+export function loadPrefs(): Record<string, unknown> {
+  try {
+    return JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
+  } catch {
+    return {}
+  }
+}
+
+export function savePrefs(patch: Record<string, unknown>): void {
+  try {
+    const current = loadPrefs()
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ ...current, ...patch }))
+  } catch { /* localStorage unavailable */ }
+}

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -9,20 +9,11 @@ import { TodosSection } from '@/components/journal/TodosSection'
 import { DailyLogSection } from '@/components/journal/DailyLogSection'
 import { NotesSection } from '@/components/journal/NotesSection'
 import type { AppContext } from '@/components/Layout'
+import { loadPrefs, savePrefs } from '@/lib/prefs'
 import '@/journal.css'
 
 type SortMode = 'manual' | 'open first' | 'done last'
 type HeaderStyle = 'stat' | 'minimal'
-
-const PREFS_KEY = 'taskflow_journal_prefs_v1'
-
-function loadPrefs() {
-  try {
-    return JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
-  } catch {
-    return {}
-  }
-}
 
 export function JournalPage() {
   const { date: urlDate } = useParams<{ date: string }>()
@@ -52,8 +43,7 @@ export function JournalPage() {
   const [projectStart, setProjectStart] = useState<string>(() => loadPrefs().projectStart ?? '2026-05-09')
 
   useEffect(() => {
-    const prefs = loadPrefs()
-    localStorage.setItem(PREFS_KEY, JSON.stringify({ ...prefs, headerStyle, todoSort, projectStart }))
+    savePrefs({ headerStyle, todoSort, projectStart })
   }, [headerStyle, todoSort, projectStart])
 
   return (

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useOutletContext } from 'react-router-dom'
 import { useEnsureJournalEntry, useJournalEntries, useJournalTodos } from '@/hooks/useJournal'
 import type { JournalEntryResponseDto, TaskItemResponseDto } from '@/api/journal'
 import { urlDateToISO, todayISO, isValidISODate } from '@/lib/journal-utils'
@@ -8,6 +8,7 @@ import { JournalHeader } from '@/components/journal/JournalHeader'
 import { TodosSection } from '@/components/journal/TodosSection'
 import { DailyLogSection } from '@/components/journal/DailyLogSection'
 import { NotesSection } from '@/components/journal/NotesSection'
+import type { AppContext } from '@/components/Layout'
 import '@/journal.css'
 
 type SortMode = 'manual' | 'open first' | 'done last'
@@ -43,20 +44,17 @@ export function JournalPage() {
   const todayTodosQuery = useJournalTodos(todayEntry?.id)
   const todayTodos = (todayTodosQuery.data?.data as TaskItemResponseDto[] | undefined) ?? []
 
+  const { isDark, setIsDark } = useOutletContext<AppContext>()
+
   // User preferences (persisted to localStorage)
   const [headerStyle, setHeaderStyle] = useState<HeaderStyle>(() => loadPrefs().headerStyle ?? 'stat')
   const [todoSort, setTodoSort] = useState<SortMode>(() => loadPrefs().todoSort ?? 'manual')
-  const [isDark, setIsDark] = useState<boolean>(() => {
-    const saved = loadPrefs().dark
-    if (saved != null) return saved
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-  })
   const [projectStart, setProjectStart] = useState<string>(() => loadPrefs().projectStart ?? '2026-05-09')
 
   useEffect(() => {
     const prefs = loadPrefs()
-    localStorage.setItem(PREFS_KEY, JSON.stringify({ ...prefs, headerStyle, todoSort, dark: isDark, projectStart }))
-  }, [headerStyle, todoSort, isDark, projectStart])
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ ...prefs, headerStyle, todoSort, projectStart }))
+  }, [headerStyle, todoSort, projectStart])
 
   return (
     <div className={'journal-page' + (isDark ? ' is-dark' : '')}>

--- a/TaskFlow.Web/src/pages/TaskDetailPage.tsx
+++ b/TaskFlow.Web/src/pages/TaskDetailPage.tsx
@@ -30,9 +30,9 @@ export function TaskDetailPage() {
   const task = taskData?.data as TaskItemResponseDto | undefined
   const notes: NoteResponseDto[] = (notesData?.data as NoteResponseDto[] | undefined) ?? []
 
-  if (!Number.isFinite(taskId)) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--danger-ink)', paddingTop: 40 }}>Task not found.</div></div>
-  if (taskLoading) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--muted)', paddingTop: 40 }}>Loading…</div></div>
-  if (taskError || !task) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--danger-ink)', paddingTop: 40 }}>Task not found.</div></div>
+  if (!Number.isFinite(taskId)) return <div className="tasks-page"><div className="t-shell"><p className="t-error">Task not found.</p></div></div>
+  if (taskLoading) return <div className="tasks-page"><div className="t-shell"><p className="t-loading">Loading…</p></div></div>
+  if (taskError || !task) return <div className="tasks-page"><div className="t-shell"><p className="t-error">Task not found.</p></div></div>
 
   function handleUpdateTask(data: CreateTaskItemDto) {
     updateTask.mutate({ id: taskId, data }, { onSuccess: () => setEditingTask(false) })
@@ -55,7 +55,7 @@ export function TaskDetailPage() {
 
   return (
     <div className="tasks-page">
-      <div className="t-shell" style={{ maxWidth: 800 }}>
+      <div className="t-shell t-shell--narrow">
         <Link to="/tasks" className="t-back-link">← Back to Tasks</Link>
 
         <div className="t-panel">
@@ -79,7 +79,7 @@ export function TaskDetailPage() {
                 <span>Priority: <strong>{task.priority}</strong></span>
                 {task.dueDate && <span>Due: <strong>{formatDate(task.dueDate)}</strong></span>}
               </div>
-              <div className="t-badges" style={{ marginTop: 14 }}>
+              <div className="t-detail-badges">
                 <span className={`t-badge t-badge-${status}`}>{status}</span>
                 <span className={`t-badge t-badge-${priority}`}>{priority}</span>
               </div>
@@ -96,7 +96,7 @@ export function TaskDetailPage() {
           </div>
 
           {showNoteForm && (
-            <div className="t-panel" style={{ marginBottom: 12 }}>
+            <div className="t-panel">
               <NoteForm
                 onSubmit={data => createNote.mutate(data, { onSuccess: () => setShowNoteForm(false) })}
                 onCancel={() => setShowNoteForm(false)}
@@ -109,10 +109,10 @@ export function TaskDetailPage() {
           ) : notes.length === 0 ? (
             <p className="t-empty">No notes yet.</p>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div className="t-note-list">
               {notes.map(note =>
                 editingNote?.id === note.id ? (
-                  <div key={String(note.id)} className="t-panel" style={{ marginBottom: 0 }}>
+                  <div key={String(note.id)} className="t-panel t-panel--flush">
                     <NoteForm
                       note={note}
                       onSubmit={data => updateNote.mutate(

--- a/TaskFlow.Web/src/pages/TaskDetailPage.tsx
+++ b/TaskFlow.Web/src/pages/TaskDetailPage.tsx
@@ -7,6 +7,7 @@ import { NoteCard } from '@/components/NoteCard'
 import { NoteForm } from '@/components/NoteForm'
 import { formatDate } from '@/lib/utils'
 import type { TaskItemResponseDto, NoteResponseDto, CreateTaskItemDto } from '@/api/client/types.gen'
+import '@/tasks.css'
 
 export function TaskDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -29,9 +30,9 @@ export function TaskDetailPage() {
   const task = taskData?.data as TaskItemResponseDto | undefined
   const notes: NoteResponseDto[] = (notesData?.data as NoteResponseDto[] | undefined) ?? []
 
-  if (!Number.isFinite(taskId)) return <div className="p-8 text-red-600">Task not found.</div>
-  if (taskLoading) return <div className="p-8 text-slate-500">Loading…</div>
-  if (taskError || !task) return <div className="p-8 text-red-600">Task not found.</div>
+  if (!Number.isFinite(taskId)) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--danger-ink)', paddingTop: 40 }}>Task not found.</div></div>
+  if (taskLoading) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--muted)', paddingTop: 40 }}>Loading…</div></div>
+  if (taskError || !task) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--danger-ink)', paddingTop: 40 }}>Task not found.</div></div>
 
   function handleUpdateTask(data: CreateTaskItemDto) {
     updateTask.mutate({ id: taskId, data }, { onSuccess: () => setEditingTask(false) })
@@ -39,7 +40,7 @@ export function TaskDetailPage() {
 
   function handleDeleteTask() {
     if (window.confirm(`Delete "${task!.title}"?`)) {
-      deleteTask.mutate(taskId, { onSuccess: () => navigate('/') })
+      deleteTask.mutate(taskId, { onSuccess: () => navigate('/tasks') })
     }
   }
 
@@ -49,98 +50,90 @@ export function TaskDetailPage() {
     }
   }
 
+  const status = String(task.status ?? 'draft').toLowerCase()
+  const priority = String(task.priority ?? 'low').toLowerCase()
+
   return (
-    <div className="mx-auto max-w-3xl p-6">
-      <nav className="mb-4">
-        <Link to="/" className="text-sm text-blue-600 hover:underline">← Back to Tasks</Link>
-      </nav>
+    <div className="tasks-page">
+      <div className="t-shell" style={{ maxWidth: 800 }}>
+        <Link to="/tasks" className="t-back-link">← Back to Tasks</Link>
 
-      {editingTask ? (
-        <div className="rounded-lg border bg-white p-6 shadow-sm mb-6">
-          <h2 className="text-lg font-semibold mb-4">Edit Task</h2>
-          <TaskForm task={task} onSubmit={handleUpdateTask} onCancel={() => setEditingTask(false)} />
-        </div>
-      ) : (
-        <div className="rounded-lg border bg-white p-6 shadow-sm mb-6">
-          <div className="flex items-start justify-between gap-4">
-            <h1 className="text-2xl font-bold text-slate-900">{task.title}</h1>
-            <div className="flex gap-2 shrink-0">
-              <button
-                onClick={() => setEditingTask(true)}
-                className="rounded px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 border"
-              >
-                Edit
-              </button>
-              <button
-                onClick={handleDeleteTask}
-                className="rounded px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 border border-red-200"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-          {task.description && (
-            <p className="mt-3 text-slate-600">{task.description}</p>
-          )}
-          <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-500">
-            <span>Status: <strong className="text-slate-700">{task.status}</strong></span>
-            <span>Priority: <strong className="text-slate-700">{task.priority}</strong></span>
-            {task.dueDate && <span>Due: <strong className="text-slate-700">{formatDate(task.dueDate)}</strong></span>}
-          </div>
-        </div>
-      )}
-
-      <div>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-slate-800">Notes</h2>
-          {!showNoteForm && !editingNote && (
-            <button
-              onClick={() => setShowNoteForm(true)}
-              className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
-            >
-              Add Note
-            </button>
-          )}
-        </div>
-
-        {showNoteForm && (
-          <div className="rounded-lg border bg-white p-4 shadow-sm mb-3">
-            <NoteForm
-              onSubmit={data => createNote.mutate(data, { onSuccess: () => setShowNoteForm(false) })}
-              onCancel={() => setShowNoteForm(false)}
-            />
-          </div>
-        )}
-
-        {notesLoading ? (
-          <p className="text-sm text-slate-400">Loading notes…</p>
-        ) : notes.length === 0 ? (
-          <p className="text-sm text-slate-400">No notes yet.</p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {notes.map(note =>
-              editingNote?.id === note.id ? (
-                <div key={String(note.id)} className="rounded-lg border bg-white p-4 shadow-sm">
-                  <NoteForm
-                    note={note}
-                    onSubmit={data => updateNote.mutate(
-                      { id: Number(note.id), data },
-                      { onSuccess: () => setEditingNote(null) }
-                    )}
-                    onCancel={() => setEditingNote(null)}
-                  />
+        <div className="t-panel">
+          {editingTask ? (
+            <>
+              <h2 className="t-panel-title">Edit Task</h2>
+              <TaskForm task={task} onSubmit={handleUpdateTask} onCancel={() => setEditingTask(false)} />
+            </>
+          ) : (
+            <>
+              <div className="t-card-row">
+                <h1 className="t-detail-title">{task.title}</h1>
+                <div className="t-card-actions">
+                  <button className="t-btn" onClick={() => setEditingTask(true)}>Edit</button>
+                  <button className="t-btn-danger" onClick={handleDeleteTask}>Delete</button>
                 </div>
-              ) : (
-                <NoteCard
-                  key={String(note.id)}
-                  note={note}
-                  onEdit={setEditingNote}
-                  onDelete={handleDeleteNote}
-                />
-              )
+              </div>
+              {task.description && <p className="t-detail-desc">{task.description}</p>}
+              <div className="t-detail-meta">
+                <span>Status: <strong>{task.status}</strong></span>
+                <span>Priority: <strong>{task.priority}</strong></span>
+                {task.dueDate && <span>Due: <strong>{formatDate(task.dueDate)}</strong></span>}
+              </div>
+              <div className="t-badges" style={{ marginTop: 14 }}>
+                <span className={`t-badge t-badge-${status}`}>{status}</span>
+                <span className={`t-badge t-badge-${priority}`}>{priority}</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div>
+          <div className="t-section-hdr">
+            <h2 className="t-section-title">Notes</h2>
+            {!showNoteForm && !editingNote && (
+              <button className="t-btn-primary" onClick={() => setShowNoteForm(true)}>Add Note</button>
             )}
           </div>
-        )}
+
+          {showNoteForm && (
+            <div className="t-panel" style={{ marginBottom: 12 }}>
+              <NoteForm
+                onSubmit={data => createNote.mutate(data, { onSuccess: () => setShowNoteForm(false) })}
+                onCancel={() => setShowNoteForm(false)}
+              />
+            </div>
+          )}
+
+          {notesLoading ? (
+            <p className="t-empty">Loading notes…</p>
+          ) : notes.length === 0 ? (
+            <p className="t-empty">No notes yet.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {notes.map(note =>
+                editingNote?.id === note.id ? (
+                  <div key={String(note.id)} className="t-panel" style={{ marginBottom: 0 }}>
+                    <NoteForm
+                      note={note}
+                      onSubmit={data => updateNote.mutate(
+                        { id: Number(note.id), data },
+                        { onSuccess: () => setEditingNote(null) }
+                      )}
+                      onCancel={() => setEditingNote(null)}
+                    />
+                  </div>
+                ) : (
+                  <NoteCard
+                    key={String(note.id)}
+                    note={note}
+                    onEdit={setEditingNote}
+                    onDelete={handleDeleteNote}
+                  />
+                )
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -57,8 +57,8 @@ export function TasksPage() {
     }
   }
 
-  if (isLoading) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--muted)', paddingTop: 40 }}>Loading tasks…</div></div>
-  if (error) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--danger-ink)', paddingTop: 40 }}>Failed to load tasks.</div></div>
+  if (isLoading) return <div className="tasks-page"><div className="t-shell"><p className="t-loading">Loading tasks…</p></div></div>
+  if (error) return <div className="tasks-page"><div className="t-shell"><p className="t-error">Failed to load tasks.</p></div></div>
 
   return (
     <div className="tasks-page">
@@ -80,8 +80,9 @@ export function TasksPage() {
         )}
 
         <div className="t-filter-row">
-          <span className="t-filter-label">Status</span>
+          <label htmlFor="status-filter" className="t-filter-label">Status</label>
           <select
+            id="status-filter"
             className="t-select"
             value={statusFilter}
             onChange={e => setStatusFilter(e.target.value as StatusFilter)}
@@ -92,8 +93,9 @@ export function TasksPage() {
             <option value="completed">Completed</option>
           </select>
 
-          <span className="t-filter-label">Priority</span>
+          <label htmlFor="priority-filter" className="t-filter-label">Priority</label>
           <select
+            id="priority-filter"
             className="t-select"
             value={priorityFilter}
             onChange={e => setPriorityFilter(e.target.value as PriorityFilter)}
@@ -104,8 +106,9 @@ export function TasksPage() {
             <option value="high">High</option>
           </select>
 
-          <span className="t-filter-label">Sort</span>
+          <label htmlFor="sort-key" className="t-filter-label">Sort</label>
           <select
+            id="sort-key"
             className="t-select"
             value={sortKey}
             onChange={e => setSortKey(e.target.value as SortKey)}

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -3,6 +3,7 @@ import { useTasksQuery, useCreateTaskMutation, useUpdateTaskMutation, useDeleteT
 import { TaskCard } from '@/components/TaskCard'
 import { TaskForm } from '@/components/TaskForm'
 import type { TaskItemResponseDto, CreateTaskItemDto } from '@/api/client/types.gen'
+import '@/tasks.css'
 
 type StatusFilter = 'all' | 'draft' | 'todo' | 'completed'
 type PriorityFilter = 'all' | 'low' | 'medium' | 'high'
@@ -56,90 +57,80 @@ export function TasksPage() {
     }
   }
 
-  if (isLoading) return <div className="p-8 text-slate-500">Loading tasks…</div>
-  if (error) return <div className="p-8 text-red-600">Failed to load tasks.</div>
+  if (isLoading) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--muted)', paddingTop: 40 }}>Loading tasks…</div></div>
+  if (error) return <div className="tasks-page"><div className="t-shell" style={{ color: 'var(--danger-ink)', paddingTop: 40 }}>Failed to load tasks.</div></div>
 
   return (
-    <div className="mx-auto max-w-4xl p-6">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-slate-900">Tasks</h1>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
-        >
-          New Task
-        </button>
-      </div>
-
-      {(showCreate || editingTask) && (
-        <div className="mb-6 rounded-lg border bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold mb-4">{editingTask ? 'Edit Task' : 'New Task'}</h2>
-          <TaskForm
-            task={editingTask ?? undefined}
-            onSubmit={editingTask ? handleUpdate : handleCreate}
-            onCancel={() => { setShowCreate(false); setEditingTask(null) }}
-          />
+    <div className="tasks-page">
+      <div className="t-shell">
+        <div className="t-page-hdr">
+          <h1 className="t-page-title">Tasks</h1>
+          <button className="t-btn-primary" onClick={() => setShowCreate(true)}>New Task</button>
         </div>
-      )}
 
-      <div className="flex flex-wrap gap-3 mb-4">
-        <div className="flex gap-2 items-center">
-          <label htmlFor="status-filter" className="text-xs text-slate-500 font-medium uppercase">Status</label>
+        {(showCreate || editingTask) && (
+          <div className="t-panel">
+            <h2 className="t-panel-title">{editingTask ? 'Edit Task' : 'New Task'}</h2>
+            <TaskForm
+              task={editingTask ?? undefined}
+              onSubmit={editingTask ? handleUpdate : handleCreate}
+              onCancel={() => { setShowCreate(false); setEditingTask(null) }}
+            />
+          </div>
+        )}
+
+        <div className="t-filter-row">
+          <span className="t-filter-label">Status</span>
           <select
-            id="status-filter"
+            className="t-select"
             value={statusFilter}
             onChange={e => setStatusFilter(e.target.value as StatusFilter)}
-            className="rounded border px-2 py-1 text-sm"
           >
             <option value="all">All</option>
             <option value="draft">Draft</option>
             <option value="todo">Todo</option>
             <option value="completed">Completed</option>
           </select>
-        </div>
-        <div className="flex gap-2 items-center">
-          <label htmlFor="priority-filter" className="text-xs text-slate-500 font-medium uppercase">Priority</label>
+
+          <span className="t-filter-label">Priority</span>
           <select
-            id="priority-filter"
+            className="t-select"
             value={priorityFilter}
             onChange={e => setPriorityFilter(e.target.value as PriorityFilter)}
-            className="rounded border px-2 py-1 text-sm"
           >
             <option value="all">All</option>
             <option value="low">Low</option>
             <option value="medium">Medium</option>
             <option value="high">High</option>
           </select>
-        </div>
-        <div className="flex gap-2 items-center">
-          <label htmlFor="sort-key" className="text-xs text-slate-500 font-medium uppercase">Sort</label>
+
+          <span className="t-filter-label">Sort</span>
           <select
-            id="sort-key"
+            className="t-select"
             value={sortKey}
             onChange={e => setSortKey(e.target.value as SortKey)}
-            className="rounded border px-2 py-1 text-sm"
           >
             <option value="title">Title</option>
             <option value="dueDate">Due Date</option>
             <option value="priority">Priority</option>
           </select>
         </div>
-      </div>
 
-      {filtered.length === 0 ? (
-        <p className="text-slate-500 text-sm">No tasks match your filters.</p>
-      ) : (
-        <div className="grid gap-3 sm:grid-cols-2">
-          {filtered.map(task => (
-            <TaskCard
-              key={String(task.id)}
-              task={task}
-              onEdit={setEditingTask}
-              onDelete={handleDelete}
-            />
-          ))}
-        </div>
-      )}
+        {filtered.length === 0 ? (
+          <p className="t-empty">No tasks match your filters.</p>
+        ) : (
+          <div className="t-card-grid">
+            {filtered.map(task => (
+              <TaskCard
+                key={String(task.id)}
+                task={task}
+                onEdit={setEditingTask}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/TaskFlow.Web/src/tasks.css
+++ b/TaskFlow.Web/src/tasks.css
@@ -1,0 +1,374 @@
+/* Tasks pages — styled to match the journal design system */
+
+.tasks-page {
+  min-height: 100vh;
+  padding: 28px 24px 80px;
+  background:
+    radial-gradient(900px 380px at 88% -120px, color-mix(in oklab, var(--accent) 4%, transparent), transparent 60%),
+    var(--bg);
+  font: 15px/1.5 system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
+}
+
+.tasks-page button,
+.tasks-page input,
+.tasks-page select,
+.tasks-page textarea {
+  font: inherit;
+  color: inherit;
+}
+
+.t-shell {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+/* ─── Page header ─────────────────────────────────────────────────────────── */
+
+.t-page-hdr {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.t-page-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  color: var(--ink);
+}
+
+/* ─── Panel (floating card) ───────────────────────────────────────────────── */
+
+.t-panel {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  padding: 22px 26px;
+  margin-bottom: 18px;
+}
+
+.t-panel-title {
+  margin: 0 0 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+/* ─── Filter bar ──────────────────────────────────────────────────────────── */
+
+.t-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+  align-items: center;
+}
+
+.t-filter-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.t-select {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 5px 10px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color .12s;
+}
+.t-select:focus { border-color: var(--accent); }
+html.is-dark .t-select { color-scheme: dark; }
+
+/* ─── Task card grid ──────────────────────────────────────────────────────── */
+
+.t-card-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+
+/* ─── Task card ───────────────────────────────────────────────────────────── */
+
+.t-card {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: box-shadow .15s;
+}
+.t-card:hover { box-shadow: var(--shadow-md); }
+
+.t-card-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.t-task-link {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--ink);
+  text-decoration: none;
+  line-height: 1.35;
+}
+.t-task-link:hover { text-decoration: underline; }
+
+.t-card-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.t-card-meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* ─── Badges ──────────────────────────────────────────────────────────────── */
+
+.t-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.t-badge {
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: .02em;
+  text-transform: lowercase;
+}
+.t-badge-draft    { background: var(--line-soft); color: var(--muted); }
+.t-badge-todo     { background: var(--accent-soft); color: var(--accent-ink); }
+.t-badge-completed {
+  background: color-mix(in oklab, #22c55e 15%, transparent);
+  color: #15803d;
+}
+html.is-dark .t-badge-completed { color: #4ade80; }
+.t-badge-low    { background: var(--line-soft); color: var(--muted); }
+.t-badge-medium {
+  background: color-mix(in oklab, #f59e0b 15%, transparent);
+  color: #b45309;
+}
+html.is-dark .t-badge-medium { color: #fbbf24; }
+.t-badge-high   { background: var(--danger-bg); color: var(--danger-ink); }
+
+/* ─── Buttons ─────────────────────────────────────────────────────────────── */
+
+.t-btn {
+  padding: 5px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.t-btn:hover {
+  background: var(--hover-soft);
+  color: var(--ink);
+  border-color: var(--line-2);
+}
+
+.t-btn-primary {
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  border: 0;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  transition: opacity .12s;
+}
+.t-btn-primary:hover { opacity: .88; }
+
+.t-btn-danger {
+  padding: 5px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in oklab, var(--danger-ink) 30%, transparent);
+  background: transparent;
+  color: var(--danger-ink);
+  cursor: pointer;
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: background .12s;
+}
+.t-btn-danger:hover { background: var(--danger-bg); }
+
+/* ─── Task detail ─────────────────────────────────────────────────────────── */
+
+.t-detail-title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  color: var(--ink);
+}
+
+.t-detail-desc {
+  margin: 10px 0 0;
+  font-size: 14.5px;
+  color: var(--ink-2);
+  line-height: 1.55;
+}
+
+.t-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.t-detail-meta strong { color: var(--ink); font-weight: 600; }
+
+.t-section-hdr {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.t-section-title {
+  margin: 0;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.t-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  text-decoration: none;
+  margin-bottom: 18px;
+  transition: color .12s;
+}
+.t-back-link:hover { color: var(--ink); }
+
+/* ─── Note card ───────────────────────────────────────────────────────────── */
+
+.t-note-card {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.t-note-content {
+  font-size: 14px;
+  color: var(--ink);
+  white-space: pre-wrap;
+  line-height: 1.55;
+}
+
+.t-note-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.t-note-date {
+  font-size: 11.5px;
+  color: var(--muted-2);
+}
+
+.t-note-actions {
+  display: flex;
+  gap: 4px;
+}
+
+/* ─── Form ────────────────────────────────────────────────────────────────── */
+
+.t-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.t-form-row {
+  display: flex;
+  gap: 16px;
+}
+.t-form-row > * { flex: 1; }
+
+.t-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.t-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.t-input {
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius-sm);
+  background: var(--paper-2);
+  color: var(--ink);
+  padding: 8px 12px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color .12s, box-shadow .12s;
+  width: 100%;
+  box-sizing: border-box;
+}
+.t-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent);
+}
+.t-input::placeholder { color: var(--muted-2); }
+html.is-dark .t-input[type="date"] { color-scheme: dark; }
+html.is-dark .t-input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(1); }
+html.is-dark .t-input option { background: var(--paper); }
+
+.t-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.t-empty {
+  font-size: 13.5px;
+  color: var(--muted-2);
+  font-style: italic;
+  padding: 8px 0;
+}

--- a/TaskFlow.Web/src/tasks.css
+++ b/TaskFlow.Web/src/tasks.css
@@ -372,3 +372,38 @@ html.is-dark .t-input option { background: var(--paper); }
   font-style: italic;
   padding: 8px 0;
 }
+
+.t-loading {
+  font-size: 14px;
+  color: var(--muted);
+  padding: 40px 0;
+}
+
+.t-error {
+  font-size: 14px;
+  color: var(--danger-ink);
+  padding: 40px 0;
+}
+
+/* ─── Detail page ─────────────────────────────────────────────────────────── */
+
+.t-shell--narrow {
+  max-width: 800px;
+}
+
+.t-detail-badges {
+  margin-top: 14px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.t-note-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.t-panel--flush {
+  margin-bottom: 0;
+}

--- a/TaskFlow.Web/src/tasks.css
+++ b/TaskFlow.Web/src/tasks.css
@@ -159,17 +159,9 @@ html.is-dark .t-select { color-scheme: dark; }
 }
 .t-badge-draft    { background: var(--line-soft); color: var(--muted); }
 .t-badge-todo     { background: var(--accent-soft); color: var(--accent-ink); }
-.t-badge-completed {
-  background: color-mix(in oklab, #22c55e 15%, transparent);
-  color: #15803d;
-}
-html.is-dark .t-badge-completed { color: #4ade80; }
-.t-badge-low    { background: var(--line-soft); color: var(--muted); }
-.t-badge-medium {
-  background: color-mix(in oklab, #f59e0b 15%, transparent);
-  color: #b45309;
-}
-html.is-dark .t-badge-medium { color: #fbbf24; }
+.t-badge-completed { background: var(--success-bg); color: var(--success-ink); }
+.t-badge-low       { background: var(--line-soft);  color: var(--muted); }
+.t-badge-medium    { background: var(--warn-bg);    color: var(--warn-ink); }
 .t-badge-high   { background: var(--danger-bg); color: var(--danger-ink); }
 
 /* ─── Buttons ─────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Lifts journal CSS design tokens (`--bg`, `--paper`, `--ink`, etc.) to `:root` / `html.is-dark` so all pages share the same color palette, typography, and shadow system
- Dark mode now defaults to `true` (previously used system preference); persisted in localStorage under the existing prefs key
- Moves dark mode state to `Layout` so it applies globally — journal page reads it from outlet context instead of managing it locally
- Rewrites tasks pages and all task components (`TaskCard`, `NoteCard`, `TaskForm`, `NoteForm`) using shared CSS vars via a new `tasks.css`, replacing hardcoded Tailwind color classes
- Nav bar updated to use CSS var-based classes matching the journal style; retains `aria-label` added in main

## Test plan

- [ ] App loads in dark mode by default (no saved preference)
- [ ] Toggling dark mode via the journal settings gear applies globally — tasks page and nav also switch
- [ ] Dark mode preference persists across page refreshes
- [ ] Tasks page matches journal aesthetic: same background, card style, typography, and accent color
- [ ] Task detail page styled consistently with tasks list
- [ ] Nav active state correct on both journal and tasks pages
- [ ] Light mode renders correctly when toggled on

🤖 Generated with [Claude Code](https://claude.com/claude-code)