### PR TITLE
Implement hamburger menu for settings and multi-theme support

### DIFF
--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -1,11 +1,19 @@
 import { useState, useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Nav } from '@/components/Nav'
+import { SettingsDrawer } from '@/components/SettingsDrawer'
 import { loadPrefs, savePrefs } from '@/lib/prefs'
+import type { SortMode, HeaderStyle } from '@/lib/prefs'
 
 export interface AppContext {
   isDark: boolean
   setIsDark: (v: boolean | ((prev: boolean) => boolean)) => void
+  headerStyle: HeaderStyle
+  setHeaderStyle: (v: HeaderStyle) => void
+  todoSort: SortMode
+  setTodoSort: (v: SortMode) => void
+  projectStart: string
+  setProjectStart: (v: string) => void
 }
 
 function loadDark(): boolean {
@@ -15,16 +23,41 @@ function loadDark(): boolean {
 
 export function Layout() {
   const [isDark, setIsDark] = useState<boolean>(loadDark)
+  const [headerStyle, setHeaderStyle] = useState<HeaderStyle>(() => loadPrefs().headerStyle ?? 'stat')
+  const [todoSort, setTodoSort] = useState<SortMode>(() => loadPrefs().todoSort ?? 'manual')
+  const [projectStart, setProjectStart] = useState<string>(() => loadPrefs().projectStart ?? '2026-05-09')
+  const [drawerOpen, setDrawerOpen] = useState(false)
 
   useEffect(() => {
     document.documentElement.classList.toggle('is-dark', isDark)
     savePrefs({ dark: isDark })
   }, [isDark])
 
+  useEffect(() => {
+    savePrefs({ headerStyle, todoSort, projectStart })
+  }, [headerStyle, todoSort, projectStart])
+
   return (
     <>
-      <Nav />
-      <Outlet context={{ isDark, setIsDark } satisfies AppContext} />
+      <Nav onMenuClick={() => setDrawerOpen(true)} />
+      <SettingsDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        isDark={isDark}
+        headerStyle={headerStyle}
+        todoSort={todoSort}
+        projectStart={projectStart}
+        onDark={v => setIsDark(v)}
+        onHeaderStyle={setHeaderStyle}
+        onTodoSort={setTodoSort}
+        onProjectStart={setProjectStart}
+      />
+      <Outlet context={{
+        isDark, setIsDark,
+        headerStyle, setHeaderStyle,
+        todoSort, setTodoSort,
+        projectStart, setProjectStart,
+      } satisfies AppContext} />
     </>
   )
 }

--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -8,6 +8,8 @@ import type { SortMode, HeaderStyle } from '@/lib/prefs'
 export interface AppContext {
   isDark: boolean
   setIsDark: (v: boolean | ((prev: boolean) => boolean)) => void
+  theme: string
+  setTheme: (v: string) => void
   headerStyle: HeaderStyle
   setHeaderStyle: (v: HeaderStyle) => void
   todoSort: SortMode
@@ -23,6 +25,7 @@ function loadDark(): boolean {
 
 export function Layout() {
   const [isDark, setIsDark] = useState<boolean>(loadDark)
+  const [theme, setTheme] = useState<string>(() => loadPrefs().theme ?? 'default')
   const [headerStyle, setHeaderStyle] = useState<HeaderStyle>(() => loadPrefs().headerStyle ?? 'stat')
   const [todoSort, setTodoSort] = useState<SortMode>(() => loadPrefs().todoSort ?? 'manual')
   const [projectStart, setProjectStart] = useState<string>(() => loadPrefs().projectStart ?? '2026-05-09')
@@ -32,6 +35,16 @@ export function Layout() {
     document.documentElement.classList.toggle('is-dark', isDark)
     savePrefs({ dark: isDark })
   }, [isDark])
+
+  useEffect(() => {
+    const el = document.documentElement
+    if (theme === 'default') {
+      el.removeAttribute('data-theme')
+    } else {
+      el.setAttribute('data-theme', theme)
+    }
+    savePrefs({ theme })
+  }, [theme])
 
   useEffect(() => {
     savePrefs({ headerStyle, todoSort, projectStart })
@@ -44,16 +57,19 @@ export function Layout() {
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         isDark={isDark}
+        theme={theme}
         headerStyle={headerStyle}
         todoSort={todoSort}
         projectStart={projectStart}
         onDark={v => setIsDark(v)}
+        onTheme={setTheme}
         onHeaderStyle={setHeaderStyle}
         onTodoSort={setTodoSort}
         onProjectStart={setProjectStart}
       />
       <Outlet context={{
         isDark, setIsDark,
+        theme, setTheme,
         headerStyle, setHeaderStyle,
         todoSort, setTodoSort,
         projectStart, setProjectStart,

--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -18,17 +18,13 @@ export interface AppContext {
   setProjectStart: (v: string) => void
 }
 
-function loadDark(): boolean {
-  const saved = loadPrefs().dark
-  return typeof saved === 'boolean' ? saved : true
-}
-
 export function Layout() {
-  const [isDark, setIsDark] = useState<boolean>(loadDark)
-  const [theme, setTheme] = useState<string>(() => loadPrefs().theme ?? 'default')
-  const [headerStyle, setHeaderStyle] = useState<HeaderStyle>(() => loadPrefs().headerStyle ?? 'stat')
-  const [todoSort, setTodoSort] = useState<SortMode>(() => loadPrefs().todoSort ?? 'manual')
-  const [projectStart, setProjectStart] = useState<string>(() => loadPrefs().projectStart ?? '2026-05-09')
+  const [initialPrefs] = useState(() => loadPrefs())
+  const [isDark, setIsDark] = useState<boolean>(() => typeof initialPrefs.dark === 'boolean' ? initialPrefs.dark : true)
+  const [theme, setTheme] = useState<string>(() => initialPrefs.theme ?? 'default')
+  const [headerStyle, setHeaderStyle] = useState<HeaderStyle>(() => initialPrefs.headerStyle ?? 'stat')
+  const [todoSort, setTodoSort] = useState<SortMode>(() => initialPrefs.todoSort ?? 'manual')
+  const [projectStart, setProjectStart] = useState<string>(() => initialPrefs.projectStart ?? '2026-05-09')
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   useEffect(() => {

--- a/TaskFlow.Web/src/components/Nav.test.tsx
+++ b/TaskFlow.Web/src/components/Nav.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { Nav } from './Nav'
@@ -6,7 +6,7 @@ import { Nav } from './Nav'
 function renderNav(initialPath: string) {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
-      <Nav />
+      <Nav onMenuClick={vi.fn()} />
     </MemoryRouter>
   )
 }

--- a/TaskFlow.Web/src/components/Nav.tsx
+++ b/TaskFlow.Web/src/components/Nav.tsx
@@ -1,13 +1,27 @@
 import { Link, useLocation } from 'react-router-dom'
 import { todayUrlDate } from '@/lib/journal-utils'
 
-export function Nav() {
+interface NavProps {
+  onMenuClick: () => void
+}
+
+export function Nav({ onMenuClick }: NavProps) {
   const { pathname } = useLocation()
   const isJournal = pathname.startsWith('/journal')
   const isTasks = pathname.startsWith('/tasks')
 
   return (
     <nav aria-label="Primary navigation" className="app-nav">
+      <button
+        className="app-nav-hamburger"
+        onClick={onMenuClick}
+        aria-label="Open settings"
+        aria-haspopup="dialog"
+      >
+        <span />
+        <span />
+        <span />
+      </button>
       <Link
         to={`/journal/${todayUrlDate()}`}
         className={`app-nav-link${isJournal ? ' is-active' : ''}`}

--- a/TaskFlow.Web/src/components/SettingsDrawer.tsx
+++ b/TaskFlow.Web/src/components/SettingsDrawer.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useRef } from 'react'
 import type { SortMode, HeaderStyle } from '@/lib/prefs'
+import { THEMES } from '@/lib/themes'
 
 interface SettingsDrawerProps {
   open: boolean
   onClose: () => void
   isDark: boolean
+  theme: string
   headerStyle: HeaderStyle
   todoSort: SortMode
   projectStart: string
   onDark: (v: boolean) => void
+  onTheme: (v: string) => void
   onHeaderStyle: (v: HeaderStyle) => void
   onTodoSort: (v: SortMode) => void
   onProjectStart: (v: string) => void
@@ -16,12 +19,11 @@ interface SettingsDrawerProps {
 
 export function SettingsDrawer({
   open, onClose,
-  isDark, headerStyle, todoSort, projectStart,
-  onDark, onHeaderStyle, onTodoSort, onProjectStart,
+  isDark, theme, headerStyle, todoSort, projectStart,
+  onDark, onTheme, onHeaderStyle, onTodoSort, onProjectStart,
 }: SettingsDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null)
 
-  // Close on Escape key
   useEffect(() => {
     if (!open) return
     const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
@@ -29,21 +31,18 @@ export function SettingsDrawer({
     return () => document.removeEventListener('keydown', handler)
   }, [open, onClose])
 
-  // Trap focus inside drawer when open
   useEffect(() => {
     if (open) drawerRef.current?.focus()
   }, [open])
 
   return (
     <>
-      {/* Backdrop */}
       <div
         className={`settings-backdrop${open ? ' is-open' : ''}`}
         onClick={onClose}
         aria-hidden="true"
       />
 
-      {/* Drawer panel */}
       <div
         ref={drawerRef}
         role="dialog"
@@ -108,6 +107,30 @@ export function SettingsDrawer({
                 <span className="settings-toggle-thumb" style={{ left: isDark ? 16 : 2 }} />
               </button>
             </DrawerRow>
+
+            <div className="settings-theme-label">Theme</div>
+            <div className="settings-theme-grid">
+              {THEMES.map(t => (
+                <button
+                  key={t.id}
+                  className={`settings-theme-swatch${t.id === theme ? ' is-active' : ''}`}
+                  title={t.label}
+                  aria-label={t.label}
+                  aria-pressed={t.id === theme}
+                  onClick={() => onTheme(t.id)}
+                  style={{
+                    background: isDark ? t.bgDark : t.bgLight,
+                    borderColor: isDark ? t.accentDark : t.accentLight,
+                  }}
+                >
+                  <span
+                    className="settings-theme-swatch-dot"
+                    style={{ background: isDark ? t.accentDark : t.accentLight }}
+                  />
+                  <span className="settings-theme-swatch-name">{t.label}</span>
+                </button>
+              ))}
+            </div>
           </section>
         </div>
       </div>

--- a/TaskFlow.Web/src/components/SettingsDrawer.tsx
+++ b/TaskFlow.Web/src/components/SettingsDrawer.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef } from 'react'
+import type { SortMode, HeaderStyle } from '@/lib/prefs'
+
+interface SettingsDrawerProps {
+  open: boolean
+  onClose: () => void
+  isDark: boolean
+  headerStyle: HeaderStyle
+  todoSort: SortMode
+  projectStart: string
+  onDark: (v: boolean) => void
+  onHeaderStyle: (v: HeaderStyle) => void
+  onTodoSort: (v: SortMode) => void
+  onProjectStart: (v: string) => void
+}
+
+export function SettingsDrawer({
+  open, onClose,
+  isDark, headerStyle, todoSort, projectStart,
+  onDark, onHeaderStyle, onTodoSort, onProjectStart,
+}: SettingsDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null)
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  // Trap focus inside drawer when open
+  useEffect(() => {
+    if (open) drawerRef.current?.focus()
+  }, [open])
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`settings-backdrop${open ? ' is-open' : ''}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-label="Settings"
+        aria-modal="true"
+        className={`settings-drawer${open ? ' is-open' : ''}`}
+        tabIndex={-1}
+      >
+        <div className="settings-drawer-header">
+          <span className="settings-drawer-title">Settings</span>
+          <button
+            className="settings-drawer-close"
+            onClick={onClose}
+            aria-label="Close settings"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="settings-drawer-body">
+          <section className="settings-section">
+            <h3 className="settings-section-title">Journal</h3>
+
+            <DrawerRow label="Header style">
+              <SegControl
+                options={['stat', 'minimal'] as const}
+                value={headerStyle}
+                onChange={v => onHeaderStyle(v as HeaderStyle)}
+              />
+            </DrawerRow>
+
+            <DrawerRow label="Todo sort">
+              <SegControl
+                options={['manual', 'open first', 'done last'] as const}
+                value={todoSort}
+                onChange={v => onTodoSort(v as SortMode)}
+              />
+            </DrawerRow>
+
+            <DrawerRow label="Project day 1">
+              <input
+                type="date"
+                value={projectStart}
+                onChange={e => e.target.value && onProjectStart(e.target.value)}
+                className="settings-date-input"
+              />
+            </DrawerRow>
+          </section>
+
+          <section className="settings-section">
+            <h3 className="settings-section-title">Appearance</h3>
+
+            <DrawerRow label="Dark mode">
+              <button
+                onClick={() => onDark(!isDark)}
+                className="settings-toggle"
+                style={{ background: isDark ? '#34c759' : 'rgba(0,0,0,.15)' }}
+                aria-label="Toggle dark mode"
+                role="switch"
+                aria-checked={isDark}
+              >
+                <span className="settings-toggle-thumb" style={{ left: isDark ? 16 : 2 }} />
+              </button>
+            </DrawerRow>
+          </section>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function DrawerRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="settings-row">
+      <span className="settings-row-label">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function SegControl<T extends string>({
+  options, value, onChange,
+}: {
+  options: readonly T[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div className="settings-seg">
+      {options.map(o => (
+        <button
+          key={o}
+          onClick={() => onChange(o)}
+          className={`settings-seg-btn${o === value ? ' is-active' : ''}`}
+        >
+          {o}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/TaskFlow.Web/src/components/SettingsDrawer.tsx
+++ b/TaskFlow.Web/src/components/SettingsDrawer.tsx
@@ -47,7 +47,9 @@ export function SettingsDrawer({
         ref={drawerRef}
         role="dialog"
         aria-label="Settings"
-        aria-modal="true"
+        aria-modal={open ? 'true' : undefined}
+        aria-hidden={!open}
+        inert={!open}
         className={`settings-drawer${open ? ' is-open' : ''}`}
         tabIndex={-1}
       >

--- a/TaskFlow.Web/src/index.css
+++ b/TaskFlow.Web/src/index.css
@@ -97,3 +97,195 @@ html.is-dark {
   background: var(--accent);
   color: #fff;
 }
+
+/* ─── Hamburger button ─────────────────────────────────────────────────────── */
+
+.app-nav-hamburger {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+  color: var(--muted);
+  transition: background .12s, color .12s;
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+.app-nav-hamburger:hover {
+  background: var(--hover-soft);
+  color: var(--ink);
+}
+.app-nav-hamburger span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  border-radius: 1px;
+  background: currentColor;
+  transition: background .12s;
+}
+
+/* ─── Settings drawer ──────────────────────────────────────────────────────── */
+
+.settings-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, .35);
+  z-index: 200;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease;
+}
+.settings-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.settings-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  z-index: 201;
+  background: var(--paper);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform .22s cubic-bezier(.4, 0, .2, 1);
+  outline: none;
+}
+.settings-drawer.is-open {
+  transform: translateX(0);
+}
+
+.settings-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+.settings-drawer-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.settings-drawer-close {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 13px;
+  transition: background .12s, color .12s;
+}
+.settings-drawer-close:hover {
+  background: var(--hover-soft);
+  color: var(--ink);
+}
+
+.settings-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 0;
+}
+
+.settings-section {
+  padding: 8px 0 4px;
+}
+.settings-section + .settings-section {
+  border-top: 1px solid var(--line);
+  margin-top: 4px;
+  padding-top: 12px;
+}
+.settings-section-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  padding: 0 20px 8px;
+  margin: 0;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 20px;
+}
+.settings-row-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+
+.settings-seg {
+  display: flex;
+  gap: 2px;
+}
+.settings-seg-btn {
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 0;
+  background: rgba(0, 0, 0, .06);
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 500;
+  transition: background .1s, color .1s;
+}
+html.is-dark .settings-seg-btn {
+  background: rgba(255, 255, 255, .07);
+}
+.settings-seg-btn.is-active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.settings-toggle {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  border-radius: 999px;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background .15s;
+}
+.settings-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .25);
+  transition: left .15s;
+}
+
+.settings-date-input {
+  font-size: 11.5px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--line-2);
+  background: var(--bg);
+  color: var(--ink);
+  cursor: pointer;
+}

--- a/TaskFlow.Web/src/index.css
+++ b/TaskFlow.Web/src/index.css
@@ -55,6 +55,372 @@ html.is-dark {
   color-scheme: dark;
 }
 
+
+/* ─── Named themes ─────────────────────────────────────────────────────────── */
+
+/* Rosé Pine */
+html[data-theme="rose-pine"] {
+  --bg: #faf4ed;
+  --paper: #fffaf3;
+  --paper-2: #f2e9de;
+  --ink: #575279;
+  --ink-2: #6e6a86;
+  --muted: #9893a5;
+  --muted-2: #b4b0c8;
+  --line: #dfdad9;
+  --line-2: #cecacd;
+  --line-soft: #f2e9e1;
+  --accent: #b4637a;
+  --accent-soft: color-mix(in oklab, #b4637a 12%, white);
+  --accent-ink: color-mix(in oklab, #b4637a 70%, #575279);
+  --hover-soft: #f2e9e1;
+  --danger-bg: #fde8e8;
+  --danger-ink: #b4637a;
+  --success-bg: color-mix(in oklab, #56949f 15%, transparent);
+  --success-ink: #286983;
+  --warn-bg: color-mix(in oklab, #ea9d34 15%, transparent);
+  --warn-ink: #a56724;
+  --shadow-sm: 0 1px 2px rgba(87,82,121,.05), 0 1px 1px rgba(87,82,121,.04);
+  --shadow-md: 0 1px 2px rgba(87,82,121,.06), 0 8px 24px rgba(87,82,121,.08);
+  color-scheme: light;
+}
+html[data-theme="rose-pine"].is-dark {
+  --bg: #191724;
+  --paper: #1f1d2e;
+  --paper-2: #26233a;
+  --ink: #e0def4;
+  --ink-2: #c4c0d9;
+  --muted: #908caa;
+  --muted-2: #6e6a86;
+  --line: #2a2837;
+  --line-2: #393552;
+  --line-soft: #211f2e;
+  --accent: #eb6f92;
+  --accent-soft: color-mix(in oklab, #eb6f92 22%, #1f1d2e);
+  --accent-ink: color-mix(in oklab, #eb6f92 35%, #e0def4);
+  --hover-soft: #242234;
+  --danger-bg: #3a1a2a;
+  --danger-ink: #eb6f92;
+  --success-bg: color-mix(in oklab, #9ccfd8 18%, #1f1d2e);
+  --success-ink: #9ccfd8;
+  --warn-bg: color-mix(in oklab, #f6c177 18%, #1f1d2e);
+  --warn-ink: #f6c177;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* Catppuccin (Latte / Mocha) */
+html[data-theme="catppuccin"] {
+  --bg: #eff1f5;
+  --paper: #ffffff;
+  --paper-2: #e6e9ef;
+  --ink: #4c4f69;
+  --ink-2: #5c5f77;
+  --muted: #7c7f93;
+  --muted-2: #9ca0b0;
+  --line: #ccd0da;
+  --line-2: #bcc0cc;
+  --line-soft: #e6e9ef;
+  --accent: #1e66f5;
+  --accent-soft: color-mix(in oklab, #1e66f5 12%, white);
+  --accent-ink: color-mix(in oklab, #1e66f5 70%, #4c4f69);
+  --hover-soft: #dce0e8;
+  --danger-bg: color-mix(in oklab, #d20f39 10%, white);
+  --danger-ink: #d20f39;
+  --success-bg: color-mix(in oklab, #40a02b 12%, white);
+  --success-ink: #40a02b;
+  --warn-bg: color-mix(in oklab, #df8e1d 12%, white);
+  --warn-ink: #df8e1d;
+  --shadow-sm: 0 1px 2px rgba(76,79,105,.05), 0 1px 1px rgba(76,79,105,.04);
+  --shadow-md: 0 1px 2px rgba(76,79,105,.06), 0 8px 24px rgba(76,79,105,.08);
+  color-scheme: light;
+}
+html[data-theme="catppuccin"].is-dark {
+  --bg: #1e1e2e;
+  --paper: #181825;
+  --paper-2: #1e1e2e;
+  --ink: #cdd6f4;
+  --ink-2: #bac2de;
+  --muted: #a6adc8;
+  --muted-2: #7f849c;
+  --line: #313244;
+  --line-2: #45475a;
+  --line-soft: #292938;
+  --accent: #89b4fa;
+  --accent-soft: color-mix(in oklab, #89b4fa 22%, #181825);
+  --accent-ink: color-mix(in oklab, #89b4fa 35%, #cdd6f4);
+  --hover-soft: #252535;
+  --danger-bg: color-mix(in oklab, #f38ba8 18%, #181825);
+  --danger-ink: #f38ba8;
+  --success-bg: color-mix(in oklab, #a6e3a1 18%, #181825);
+  --success-ink: #a6e3a1;
+  --warn-bg: color-mix(in oklab, #f9e2af 18%, #181825);
+  --warn-ink: #f9e2af;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* Tokyo Night */
+html[data-theme="tokyo-night"] {
+  --bg: #e1e2e7;
+  --paper: #f0f0f4;
+  --paper-2: #e9e9ed;
+  --ink: #3760bf;
+  --ink-2: #5a6a8e;
+  --muted: #8990b3;
+  --muted-2: #a8aecb;
+  --line: #c8c9d6;
+  --line-2: #b8b9c9;
+  --line-soft: #d8d9e3;
+  --accent: #2e7de9;
+  --accent-soft: color-mix(in oklab, #2e7de9 12%, white);
+  --accent-ink: color-mix(in oklab, #2e7de9 70%, #3760bf);
+  --hover-soft: #d0d1df;
+  --danger-bg: color-mix(in oklab, #f52a65 10%, white);
+  --danger-ink: #f52a65;
+  --success-bg: color-mix(in oklab, #587539 12%, white);
+  --success-ink: #587539;
+  --warn-bg: color-mix(in oklab, #8c6c3e 12%, white);
+  --warn-ink: #8c6c3e;
+  --shadow-sm: 0 1px 2px rgba(55,96,191,.05), 0 1px 1px rgba(55,96,191,.04);
+  --shadow-md: 0 1px 2px rgba(55,96,191,.06), 0 8px 24px rgba(55,96,191,.08);
+  color-scheme: light;
+}
+html[data-theme="tokyo-night"].is-dark {
+  --bg: #1a1b26;
+  --paper: #24283b;
+  --paper-2: #1f2335;
+  --ink: #c0caf5;
+  --ink-2: #a9b1d6;
+  --muted: #9aa5ce;
+  --muted-2: #565f89;
+  --line: #292e42;
+  --line-2: #3b4261;
+  --line-soft: #202330;
+  --accent: #7aa2f7;
+  --accent-soft: color-mix(in oklab, #7aa2f7 22%, #24283b);
+  --accent-ink: color-mix(in oklab, #7aa2f7 35%, #c0caf5);
+  --hover-soft: #1e2231;
+  --danger-bg: color-mix(in oklab, #f7768e 18%, #24283b);
+  --danger-ink: #f7768e;
+  --success-bg: color-mix(in oklab, #9ece6a 18%, #24283b);
+  --success-ink: #9ece6a;
+  --warn-bg: color-mix(in oklab, #e0af68 18%, #24283b);
+  --warn-ink: #e0af68;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* Dracula */
+html[data-theme="dracula"] {
+  --bg: #f8f8f2;
+  --paper: #ffffff;
+  --paper-2: #f0f0eb;
+  --ink: #282a36;
+  --ink-2: #44475a;
+  --muted: #6272a4;
+  --muted-2: #8895cc;
+  --line: #dcdcdc;
+  --line-2: #ccc;
+  --line-soft: #f0f0f0;
+  --accent: #6272a4;
+  --accent-soft: color-mix(in oklab, #6272a4 12%, white);
+  --accent-ink: color-mix(in oklab, #6272a4 70%, #282a36);
+  --hover-soft: #ededf0;
+  --danger-bg: color-mix(in oklab, #ff5555 10%, white);
+  --danger-ink: #c0392b;
+  --success-bg: color-mix(in oklab, #50fa7b 12%, white);
+  --success-ink: #27ae60;
+  --warn-bg: color-mix(in oklab, #f1fa8c 12%, white);
+  --warn-ink: #856404;
+  --shadow-sm: 0 1px 2px rgba(40,42,54,.05), 0 1px 1px rgba(40,42,54,.04);
+  --shadow-md: 0 1px 2px rgba(40,42,54,.06), 0 8px 24px rgba(40,42,54,.08);
+  color-scheme: light;
+}
+html[data-theme="dracula"].is-dark {
+  --bg: #282a36;
+  --paper: #1e1f29;
+  --paper-2: #21222c;
+  --ink: #f8f8f2;
+  --ink-2: #e2e2dc;
+  --muted: #6272a4;
+  --muted-2: #44475a;
+  --line: #383a4a;
+  --line-2: #44475a;
+  --line-soft: #30323f;
+  --accent: #bd93f9;
+  --accent-soft: color-mix(in oklab, #bd93f9 22%, #1e1f29);
+  --accent-ink: color-mix(in oklab, #bd93f9 35%, #f8f8f2);
+  --hover-soft: #2d2f3f;
+  --danger-bg: color-mix(in oklab, #ff5555 18%, #1e1f29);
+  --danger-ink: #ff5555;
+  --success-bg: color-mix(in oklab, #50fa7b 18%, #1e1f29);
+  --success-ink: #50fa7b;
+  --warn-bg: color-mix(in oklab, #f1fa8c 18%, #1e1f29);
+  --warn-ink: #f1fa8c;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* Nord */
+html[data-theme="nord"] {
+  --bg: #eceff4;
+  --paper: #ffffff;
+  --paper-2: #e5e9f0;
+  --ink: #2e3440;
+  --ink-2: #3b4252;
+  --muted: #4c566a;
+  --muted-2: #8892a4;
+  --line: #d8dee9;
+  --line-2: #c8d0de;
+  --line-soft: #e5e9f0;
+  --accent: #5e81ac;
+  --accent-soft: color-mix(in oklab, #5e81ac 12%, white);
+  --accent-ink: color-mix(in oklab, #5e81ac 70%, #2e3440);
+  --hover-soft: #e0e4ed;
+  --danger-bg: color-mix(in oklab, #bf616a 10%, white);
+  --danger-ink: #bf616a;
+  --success-bg: color-mix(in oklab, #a3be8c 12%, white);
+  --success-ink: #4c7a34;
+  --warn-bg: color-mix(in oklab, #ebcb8b 12%, white);
+  --warn-ink: #9a6e0a;
+  --shadow-sm: 0 1px 2px rgba(46,52,64,.05), 0 1px 1px rgba(46,52,64,.04);
+  --shadow-md: 0 1px 2px rgba(46,52,64,.06), 0 8px 24px rgba(46,52,64,.08);
+  color-scheme: light;
+}
+html[data-theme="nord"].is-dark {
+  --bg: #2e3440;
+  --paper: #3b4252;
+  --paper-2: #434c5e;
+  --ink: #eceff4;
+  --ink-2: #d8dee9;
+  --muted: #8892a4;
+  --muted-2: #4c566a;
+  --line: #3b4252;
+  --line-2: #434c5e;
+  --line-soft: #353c4a;
+  --accent: #88c0d0;
+  --accent-soft: color-mix(in oklab, #88c0d0 22%, #3b4252);
+  --accent-ink: color-mix(in oklab, #88c0d0 35%, #eceff4);
+  --hover-soft: #3a4155;
+  --danger-bg: color-mix(in oklab, #bf616a 18%, #3b4252);
+  --danger-ink: #bf616a;
+  --success-bg: color-mix(in oklab, #a3be8c 18%, #3b4252);
+  --success-ink: #a3be8c;
+  --warn-bg: color-mix(in oklab, #ebcb8b 18%, #3b4252);
+  --warn-ink: #ebcb8b;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* Gruvbox */
+html[data-theme="gruvbox"] {
+  --bg: #fbf1c7;
+  --paper: #fffbf0;
+  --paper-2: #f2e5bc;
+  --ink: #3c3836;
+  --ink-2: #504945;
+  --muted: #7c6f64;
+  --muted-2: #928374;
+  --line: #d5c4a1;
+  --line-2: #c0a87c;
+  --line-soft: #ede0b6;
+  --accent: #b57614;
+  --accent-soft: color-mix(in oklab, #b57614 12%, white);
+  --accent-ink: color-mix(in oklab, #b57614 70%, #3c3836);
+  --hover-soft: #ede0b6;
+  --danger-bg: color-mix(in oklab, #cc241d 10%, #fbf1c7);
+  --danger-ink: #9d0006;
+  --success-bg: color-mix(in oklab, #98971a 12%, #fbf1c7);
+  --success-ink: #79740e;
+  --warn-bg: color-mix(in oklab, #d79921 12%, #fbf1c7);
+  --warn-ink: #b57614;
+  --shadow-sm: 0 1px 2px rgba(60,56,54,.05), 0 1px 1px rgba(60,56,54,.04);
+  --shadow-md: 0 1px 2px rgba(60,56,54,.06), 0 8px 24px rgba(60,56,54,.08);
+  color-scheme: light;
+}
+html[data-theme="gruvbox"].is-dark {
+  --bg: #282828;
+  --paper: #1d2021;
+  --paper-2: #32302f;
+  --ink: #ebdbb2;
+  --ink-2: #d5c4a1;
+  --muted: #928374;
+  --muted-2: #7c6f64;
+  --line: #3c3836;
+  --line-2: #504945;
+  --line-soft: #2a2725;
+  --accent: #d79921;
+  --accent-soft: color-mix(in oklab, #d79921 22%, #1d2021);
+  --accent-ink: color-mix(in oklab, #d79921 35%, #ebdbb2);
+  --hover-soft: #2f2c2a;
+  --danger-bg: color-mix(in oklab, #fb4934 18%, #1d2021);
+  --danger-ink: #fb4934;
+  --success-bg: color-mix(in oklab, #b8bb26 18%, #1d2021);
+  --success-ink: #b8bb26;
+  --warn-bg: color-mix(in oklab, #fabd2f 18%, #1d2021);
+  --warn-ink: #fabd2f;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* Kanagawa */
+html[data-theme="kanagawa"] {
+  --bg: #f2ecbc;
+  --paper: #fffff0;
+  --paper-2: #ebe5b5;
+  --ink: #43436c;
+  --ink-2: #54546d;
+  --muted: #a09cac;
+  --muted-2: #c8c093;
+  --line: #dcd7ba;
+  --line-2: #c8c093;
+  --line-soft: #e8e3c3;
+  --accent: #4e8ca2;
+  --accent-soft: color-mix(in oklab, #4e8ca2 12%, white);
+  --accent-ink: color-mix(in oklab, #4e8ca2 70%, #43436c);
+  --hover-soft: #e4dfb9;
+  --danger-bg: color-mix(in oklab, #c34043 10%, #f2ecbc);
+  --danger-ink: #c34043;
+  --success-bg: color-mix(in oklab, #76946a 12%, #f2ecbc);
+  --success-ink: #76946a;
+  --warn-bg: color-mix(in oklab, #dca561 12%, #f2ecbc);
+  --warn-ink: #b6843e;
+  --shadow-sm: 0 1px 2px rgba(67,67,108,.05), 0 1px 1px rgba(67,67,108,.04);
+  --shadow-md: 0 1px 2px rgba(67,67,108,.06), 0 8px 24px rgba(67,67,108,.08);
+  color-scheme: light;
+}
+html[data-theme="kanagawa"].is-dark {
+  --bg: #1f1f28;
+  --paper: #16161d;
+  --paper-2: #1a1a22;
+  --ink: #dcd7ba;
+  --ink-2: #c8c093;
+  --muted: #727169;
+  --muted-2: #54546d;
+  --line: #2a2a37;
+  --line-2: #363646;
+  --line-soft: #1e1e26;
+  --accent: #7e9cd8;
+  --accent-soft: color-mix(in oklab, #7e9cd8 22%, #16161d);
+  --accent-ink: color-mix(in oklab, #7e9cd8 35%, #dcd7ba);
+  --hover-soft: #23232f;
+  --danger-bg: color-mix(in oklab, #c34043 18%, #16161d);
+  --danger-ink: #e46876;
+  --success-bg: color-mix(in oklab, #76946a 18%, #16161d);
+  --success-ink: #98bb6c;
+  --warn-bg: color-mix(in oklab, #dca561 18%, #16161d);
+  --warn-ink: #dca561;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4), 0 1px 1px rgba(0,0,0,.3);
+  --shadow-md: 0 1px 2px rgba(0,0,0,.45), 0 12px 32px rgba(0,0,0,.45);
+  color-scheme: dark;
+}
 @layer base {
   * { border-color: var(--line); }
 
@@ -288,4 +654,58 @@ html.is-dark .settings-seg-btn {
   background: var(--bg);
   color: var(--ink);
   cursor: pointer;
+}
+
+/* ─── Theme picker swatches ─────────────────────────────────────────────────── */
+
+.settings-theme-label {
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 12px 0 6px;
+}
+
+.settings-theme-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.settings-theme-swatch {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: border-color .15s, opacity .15s;
+  font-size: .78rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.settings-theme-swatch:hover {
+  opacity: .85;
+}
+
+.settings-theme-swatch.is-active {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.settings-theme-swatch-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.settings-theme-swatch-name {
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/TaskFlow.Web/src/lib/prefs.ts
+++ b/TaskFlow.Web/src/lib/prefs.ts
@@ -1,5 +1,8 @@
 export const PREFS_KEY = 'taskflow_journal_prefs_v1'
 
+export type SortMode = 'manual' | 'open first' | 'done last'
+export type HeaderStyle = 'stat' | 'minimal'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function loadPrefs(): Record<string, any> {
   try {

--- a/TaskFlow.Web/src/lib/prefs.ts
+++ b/TaskFlow.Web/src/lib/prefs.ts
@@ -3,16 +3,23 @@ export const PREFS_KEY = 'taskflow_journal_prefs_v1'
 export type SortMode = 'manual' | 'open first' | 'done last'
 export type HeaderStyle = 'stat' | 'minimal'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function loadPrefs(): Record<string, any> {
+export interface Prefs {
+  dark?: boolean
+  theme?: string
+  headerStyle?: HeaderStyle
+  todoSort?: SortMode
+  projectStart?: string
+}
+
+export function loadPrefs(): Prefs {
   try {
-    return JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}')
+    return JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}') as Prefs
   } catch {
     return {}
   }
 }
 
-export function savePrefs(patch: Record<string, unknown>): void {
+export function savePrefs(patch: Partial<Prefs>): void {
   try {
     const current = loadPrefs()
     localStorage.setItem(PREFS_KEY, JSON.stringify({ ...current, ...patch }))

--- a/TaskFlow.Web/src/lib/themes.ts
+++ b/TaskFlow.Web/src/lib/themes.ts
@@ -1,0 +1,75 @@
+export interface Theme {
+  id: string
+  label: string
+  accentLight: string
+  accentDark: string
+  bgLight: string
+  bgDark: string
+}
+
+export const THEMES: Theme[] = [
+  {
+    id: 'default',
+    label: 'Default',
+    accentLight: '#2563eb',
+    accentDark: '#2563eb',
+    bgLight: '#f6f7f9',
+    bgDark: '#0b1220',
+  },
+  {
+    id: 'rose-pine',
+    label: 'Ros\u00e9 Pine',
+    accentLight: '#b4637a',
+    accentDark: '#eb6f92',
+    bgLight: '#faf4ed',
+    bgDark: '#191724',
+  },
+  {
+    id: 'catppuccin',
+    label: 'Catppuccin',
+    accentLight: '#1e66f5',
+    accentDark: '#89b4fa',
+    bgLight: '#eff1f5',
+    bgDark: '#1e1e2e',
+  },
+  {
+    id: 'tokyo-night',
+    label: 'Tokyo Night',
+    accentLight: '#2e7de9',
+    accentDark: '#7aa2f7',
+    bgLight: '#e1e2e7',
+    bgDark: '#24283b',
+  },
+  {
+    id: 'dracula',
+    label: 'Dracula',
+    accentLight: '#6272a4',
+    accentDark: '#bd93f9',
+    bgLight: '#f8f8f2',
+    bgDark: '#282a36',
+  },
+  {
+    id: 'nord',
+    label: 'Nord',
+    accentLight: '#5e81ac',
+    accentDark: '#88c0d0',
+    bgLight: '#eceff4',
+    bgDark: '#2e3440',
+  },
+  {
+    id: 'gruvbox',
+    label: 'Gruvbox',
+    accentLight: '#b57614',
+    accentDark: '#d79921',
+    bgLight: '#fbf1c7',
+    bgDark: '#282828',
+  },
+  {
+    id: 'kanagawa',
+    label: 'Kanagawa',
+    accentLight: '#4e8ca2',
+    accentDark: '#7e9cd8',
+    bgLight: '#f2ecbc',
+    bgDark: '#1f1f28',
+  },
+]

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useParams, useOutletContext } from 'react-router-dom'
 import { useEnsureJournalEntry, useJournalEntries, useJournalTodos } from '@/hooks/useJournal'
 import type { JournalEntryResponseDto, TaskItemResponseDto } from '@/api/journal'
@@ -9,11 +9,7 @@ import { TodosSection } from '@/components/journal/TodosSection'
 import { DailyLogSection } from '@/components/journal/DailyLogSection'
 import { NotesSection } from '@/components/journal/NotesSection'
 import type { AppContext } from '@/components/Layout'
-import { loadPrefs, savePrefs } from '@/lib/prefs'
 import '@/journal.css'
-
-type SortMode = 'manual' | 'open first' | 'done last'
-type HeaderStyle = 'stat' | 'minimal'
 
 export function JournalPage() {
   const { date: urlDate } = useParams<{ date: string }>()
@@ -35,16 +31,7 @@ export function JournalPage() {
   const todayTodosQuery = useJournalTodos(todayEntry?.id)
   const todayTodos = (todayTodosQuery.data?.data as TaskItemResponseDto[] | undefined) ?? []
 
-  const { isDark, setIsDark } = useOutletContext<AppContext>()
-
-  // User preferences (persisted to localStorage)
-  const [headerStyle, setHeaderStyle] = useState<HeaderStyle>(() => loadPrefs().headerStyle ?? 'stat')
-  const [todoSort, setTodoSort] = useState<SortMode>(() => loadPrefs().todoSort ?? 'manual')
-  const [projectStart, setProjectStart] = useState<string>(() => loadPrefs().projectStart ?? '2026-05-09')
-
-  useEffect(() => {
-    savePrefs({ headerStyle, todoSort, projectStart })
-  }, [headerStyle, todoSort, projectStart])
+  const { isDark, headerStyle, todoSort, projectStart } = useOutletContext<AppContext>()
 
   return (
     <div className={'journal-page' + (isDark ? ' is-dark' : '')}>
@@ -87,154 +74,7 @@ export function JournalPage() {
             </>
           ) : null}
         </article>
-
-        <PrefsBar
-          headerStyle={headerStyle}
-          todoSort={todoSort}
-          isDark={isDark}
-          projectStart={projectStart}
-          onHeaderStyle={setHeaderStyle}
-          onTodoSort={setTodoSort}
-          onDark={setIsDark}
-          onProjectStart={setProjectStart}
-        />
       </div>
-    </div>
-  )
-}
-
-// ─── Minimal prefs bar ────────────────────────────────────────────────────────
-
-interface PrefsBarProps {
-  headerStyle: HeaderStyle
-  todoSort: SortMode
-  isDark: boolean
-  projectStart: string
-  onHeaderStyle: (v: HeaderStyle) => void
-  onTodoSort: (v: SortMode) => void
-  onDark: (v: boolean) => void
-  onProjectStart: (v: string) => void
-}
-
-function PrefsBar({ headerStyle, todoSort, isDark, projectStart, onHeaderStyle, onTodoSort, onDark, onProjectStart }: PrefsBarProps) {
-  const [open, setOpen] = useState(false)
-
-  return (
-    <div style={{ position: 'fixed', bottom: 20, right: 20, zIndex: 100 }}>
-      {open && (
-        <div style={{
-          marginBottom: 8,
-          padding: '14px 16px',
-          background: isDark ? '#1a2438' : '#fff',
-          border: '1px solid var(--line)',
-          borderRadius: 12,
-          boxShadow: 'var(--shadow-md)',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 12,
-          minWidth: 220,
-          fontSize: 13,
-          color: 'var(--ink)',
-        }}>
-          <PrefRow label="Header">
-            <SegControl
-              options={['stat', 'minimal'] as const}
-              value={headerStyle}
-              onChange={v => onHeaderStyle(v as HeaderStyle)}
-            />
-          </PrefRow>
-          <PrefRow label="Sort">
-            <SegControl
-              options={['manual', 'open first', 'done last'] as const}
-              value={todoSort}
-              onChange={v => onTodoSort(v as SortMode)}
-            />
-          </PrefRow>
-          <PrefRow label="Dark mode">
-            <button
-              onClick={() => onDark(!isDark)}
-              style={{
-                width: 32, height: 18, borderRadius: 999,
-                background: isDark ? '#34c759' : 'rgba(0,0,0,.15)',
-                border: 0, cursor: 'pointer', padding: 0, position: 'relative',
-                transition: 'background .15s',
-              }}
-              aria-label="Toggle dark mode"
-              role="switch"
-              aria-checked={isDark}
-            >
-              <span style={{
-                position: 'absolute', top: 2, left: isDark ? 16 : 2, width: 14, height: 14,
-                borderRadius: '50%', background: '#fff',
-                boxShadow: '0 1px 2px rgba(0,0,0,.25)',
-                transition: 'left .15s',
-              }} />
-            </button>
-          </PrefRow>
-          <PrefRow label="Day 1">
-            <input
-              type="date"
-              value={projectStart}
-              onChange={e => e.target.value && onProjectStart(e.target.value)}
-              style={{
-                fontSize: 11.5, padding: '3px 6px', borderRadius: 6,
-                border: '1px solid var(--line-2)',
-                background: isDark ? '#0b1220' : '#f8fafc',
-                color: 'var(--ink)', cursor: 'pointer',
-              }}
-            />
-          </PrefRow>
-        </div>
-      )}
-      <button
-        onClick={() => setOpen(o => !o)}
-        style={{
-          width: 36, height: 36, borderRadius: '50%',
-          background: 'var(--accent)', color: '#fff',
-          border: 0, cursor: 'pointer', fontSize: 16,
-          boxShadow: 'var(--shadow-md)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-        }}
-        aria-label="Journal settings"
-      >
-        ⚙
-      </button>
-    </div>
-  )
-}
-
-function PrefRow({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-      <span style={{ fontWeight: 500, color: 'var(--muted)' }}>{label}</span>
-      {children}
-    </div>
-  )
-}
-
-function SegControl<T extends string>({
-  options, value, onChange,
-}: {
-  options: readonly T[]
-  value: T
-  onChange: (v: T) => void
-}) {
-  return (
-    <div style={{ display: 'flex', gap: 2 }}>
-      {options.map(o => (
-        <button
-          key={o}
-          onClick={() => onChange(o)}
-          style={{
-            padding: '3px 8px', borderRadius: 6, border: 0,
-            background: o === value ? 'var(--accent)' : 'rgba(0,0,0,.06)',
-            color: o === value ? '#fff' : 'var(--ink)',
-            cursor: 'pointer', fontSize: 11.5, fontWeight: 500,
-          }}
-        >
-          {o}
-        </button>
-      ))}
     </div>
   )
 }


### PR DESCRIPTION
This pull request introduces a new, unified settings drawer for user preferences and theming, replacing the previous floating preferences bar. It centralizes appearance and journal settings, improves accessibility, and adds support for multiple color themes. The changes also refactor preference management to use a single context and type-safe interfaces.

**Settings UI and User Preferences**

* Added a new `SettingsDrawer` component, accessible via a hamburger menu in the navigation bar, to manage appearance and journal preferences in a single, accessible modal. This replaces the previous floating `PrefsBar` in the journal page. [[1]](diffhunk://#diff-0952065e38c5d95d8e8d24bb8e059a9fee44f305d92e66a241685a66789268beR1-R170) [[2]](diffhunk://#diff-a4c7d0f4298ddeeb94c46cdd77c1da5ccb75d9d3876517911c6b12d4a3bfd9f4R28-R76) Feb6f037L1, [[3]](diffhunk://#diff-fb527dd0fd05483858456318a6c0f2aaa7abf6cc44aba8570a1ba99e41ebaed5L90-L237)
* Updated `Layout` and navigation components to support opening the settings drawer and passing preference state via context, ensuring consistent preference management across the app. [[1]](diffhunk://#diff-a4c7d0f4298ddeeb94c46cdd77c1da5ccb75d9d3876517911c6b12d4a3bfd9f4R4-R18) [[2]](diffhunk://#diff-a4c7d0f4298ddeeb94c46cdd77c1da5ccb75d9d3876517911c6b12d4a3bfd9f4R28-R76) Feb6f037L1, [[3]](diffhunk://#diff-581b426181d92767bd774b8f152fe61d39611cf9872159999b84a4e7fcfd0a36L1-R9)

**Theming and Appearance**

* Introduced a new theming system with multiple built-in color themes (e.g., Default, Rosé Pine, Catppuccin, etc.), selectable in the settings drawer and persisted in user preferences. [[1]](diffhunk://#diff-0952065e38c5d95d8e8d24bb8e059a9fee44f305d92e66a241685a66789268beR1-R170) [[2]](diffhunk://#diff-984b453b72b76210a1820bd1379bffebf35d75c2d1159d1e4a4467c880475f00R1-R75) [[3]](diffhunk://#diff-a4c7d0f4298ddeeb94c46cdd77c1da5ccb75d9d3876517911c6b12d4a3bfd9f4R28-R76)

**Preference Persistence and Types**

* Refactored preference loading and saving to use a typed `Prefs` interface, improving type safety and maintainability.
* Centralized all user preferences (dark mode, theme, header style, todo sort, project start date) in context, removing redundant state and effect logic from individual pages. [[1]](diffhunk://#diff-a4c7d0f4298ddeeb94c46cdd77c1da5ccb75d9d3876517911c6b12d4a3bfd9f4R4-R18) [[2]](diffhunk://#diff-fb527dd0fd05483858456318a6c0f2aaa7abf6cc44aba8570a1ba99e41ebaed5L38-R34) [[3]](diffhunk://#diff-fb527dd0fd05483858456318a6c0f2aaa7abf6cc44aba8570a1ba99e41ebaed5L12-L17)

**Code Cleanup**

* Removed the old `PrefsBar` and related preference UI from `JournalPage`, cleaning up unused code and simplifying the page component.

These changes streamline the user experience for customizing appearance and journal behavior, and lay the groundwork for further extensibility in user preferences.