### PR TITLE
feat: replace task card grid with sortable list view

### DIFF
--- a/TaskFlow.Web/src/components/TaskListRow.test.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { TaskListRow } from './TaskListRow'
+import type { TaskItemResponseDto } from '@/api/client/types.gen'
+
+const baseTask: TaskItemResponseDto = {
+  id: 42,
+  title: 'Fix login bug',
+  description: 'Users cannot log in',
+  status: 'todo',
+  priority: 'high',
+  dueDate: null,
+  isComplete: false,
+}
+
+function renderRow(
+  task: TaskItemResponseDto = baseTask,
+  isOnTodayJournal = false,
+  onEdit = vi.fn(),
+  onDelete = vi.fn(),
+) {
+  return render(
+    <MemoryRouter>
+      <table>
+        <tbody>
+          <TaskListRow
+            task={task}
+            isOnTodayJournal={isOnTodayJournal}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        </tbody>
+      </table>
+    </MemoryRouter>
+  )
+}
+
+describe('TaskListRow', () => {
+  it('renders the task title as a link', () => {
+    renderRow()
+    expect(screen.getByRole('link', { name: 'Fix login bug' })).toBeInTheDocument()
+  })
+
+  it('renders status and priority badges', () => {
+    renderRow()
+    expect(screen.getByText('todo')).toBeInTheDocument()
+    expect(screen.getByText('high')).toBeInTheDocument()
+  })
+
+  it('calls onEdit when edit button is clicked', async () => {
+    const onEdit = vi.fn()
+    renderRow(baseTask, false, onEdit)
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }))
+    expect(onEdit).toHaveBeenCalledWith(baseTask)
+  })
+
+  it('calls onDelete when delete button is clicked', async () => {
+    const onDelete = vi.fn()
+    renderRow(baseTask, false, vi.fn(), onDelete)
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }))
+    expect(onDelete).toHaveBeenCalledWith(baseTask)
+  })
+
+  it('shows journal indicator when task is on today journal', () => {
+    renderRow(baseTask, true)
+    expect(screen.getByLabelText("On today's journal")).toBeInTheDocument()
+  })
+
+  it('does not show journal indicator when task is not on today journal', () => {
+    renderRow(baseTask, false)
+    expect(screen.queryByLabelText("On today's journal")).not.toBeInTheDocument()
+  })
+
+  it('shows formatted due date when present', () => {
+    const task = { ...baseTask, dueDate: '2026-06-15T12:00:00Z' }
+    renderRow(task)
+    expect(screen.getByText(/Jun 15, 2026/)).toBeInTheDocument()
+  })
+
+  it('shows em dash when no due date', () => {
+    renderRow({ ...baseTask, dueDate: null })
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  describe('overdue indicator', () => {
+    const pastDate = '2020-01-01T00:00:00Z'
+
+    it('marks past-due incomplete tasks as overdue', () => {
+      const task = { ...baseTask, dueDate: pastDate, status: 'todo' }
+      renderRow(task)
+      // The overdue icon (!) should be present
+      expect(screen.getByText('!', { selector: '.t-overdue-icon' })).toBeInTheDocument()
+    })
+
+    it('does not mark completed tasks as overdue even if past due', () => {
+      const task = { ...baseTask, dueDate: pastDate, status: 'Completed' }
+      renderRow(task)
+      expect(screen.queryByText('!', { selector: '.t-overdue-icon' })).not.toBeInTheDocument()
+    })
+
+    it('does not mark future tasks as overdue', () => {
+      const task = { ...baseTask, dueDate: '2099-12-31T00:00:00Z', status: 'todo' }
+      renderRow(task)
+      expect(screen.queryByText('!', { selector: '.t-overdue-icon' })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/TaskFlow.Web/src/components/TaskListRow.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.tsx
@@ -1,0 +1,61 @@
+import { Link } from 'react-router-dom'
+import { formatDate } from '@/lib/utils'
+import type { TaskItemResponseDto } from '@/api/client/types.gen'
+
+interface Props {
+  task: TaskItemResponseDto
+  isOnTodayJournal: boolean
+  onEdit: (task: TaskItemResponseDto) => void
+  onDelete: (task: TaskItemResponseDto) => void
+}
+
+function isOverdue(dueDate: string | null | undefined, status: string | undefined): boolean {
+  if (!dueDate) return false
+  if ((status ?? '').toLowerCase() === 'completed') return false
+  return new Date(dueDate) < new Date(new Date().toDateString())
+}
+
+export function TaskListRow({ task, isOnTodayJournal, onEdit, onDelete }: Props) {
+  const status = (task.status ?? 'draft').toLowerCase()
+  const priority = (task.priority ?? 'low').toLowerCase()
+  const overdue = isOverdue(task.dueDate, task.status)
+
+  return (
+    <tr className="t-list-row">
+      <td className="t-list-cell t-list-cell--title">
+        <Link to={`/tasks/${task.id}`} className="t-task-link">
+          {task.title}
+        </Link>
+      </td>
+      <td className="t-list-cell">
+        <span className={`t-badge t-badge-${status}`}>{status}</span>
+      </td>
+      <td className="t-list-cell">
+        <span className={`t-badge t-badge-${priority}`}>{priority}</span>
+      </td>
+      <td className="t-list-cell t-list-cell--due">
+        {task.dueDate ? (
+          <span className={overdue ? 't-overdue' : ''}>
+            {overdue && <span className="t-overdue-icon" aria-hidden="true">!</span>}
+            {formatDate(task.dueDate)}
+          </span>
+        ) : (
+          <span className="t-list-empty">—</span>
+        )}
+      </td>
+      <td className="t-list-cell t-list-cell--journal">
+        {isOnTodayJournal && (
+          <span className="t-journal-dot" title="On today's journal" aria-label="On today's journal">
+            📔
+          </span>
+        )}
+      </td>
+      <td className="t-list-cell t-list-cell--actions">
+        <div className="t-card-actions">
+          <button className="t-btn" aria-label="Edit" onClick={() => onEdit(task)}>Edit</button>
+          <button className="t-btn-danger" aria-label="Delete" onClick={() => onDelete(task)}>Delete</button>
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/TaskFlow.Web/src/components/TaskListRow.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { formatDate } from '@/lib/utils'
+import { todayISO } from '@/lib/journal-utils'
 import type { TaskItemResponseDto } from '@/api/client/types.gen'
 
 interface Props {
@@ -12,7 +13,8 @@ interface Props {
 function isOverdue(dueDate: string | null | undefined, status: string | undefined): boolean {
   if (!dueDate) return false
   if ((status ?? '').toLowerCase() === 'completed') return false
-  return new Date(dueDate) < new Date(new Date().toDateString())
+  // Compare ISO date strings (YYYY-MM-DD) to avoid timezone offset issues with UTC-stored dates
+  return dueDate.slice(0, 10) < todayISO()
 }
 
 export function TaskListRow({ task, isOnTodayJournal, onEdit, onDelete }: Props) {

--- a/TaskFlow.Web/src/components/TaskListRow.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.tsx
@@ -47,7 +47,7 @@ export function TaskListRow({ task, isOnTodayJournal, onEdit, onDelete }: Props)
       </td>
       <td className="t-list-cell t-list-cell--journal">
         {isOnTodayJournal && (
-          <span className="t-journal-dot" title="On today's journal" aria-label="On today's journal">
+          <span className="t-journal-dot" title="On today's journal" role="img" aria-label="On today's journal">
             📔
           </span>
         )}

--- a/TaskFlow.Web/src/components/TaskListRow.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.tsx
@@ -37,7 +37,10 @@ export function TaskListRow({ task, isOnTodayJournal, onEdit, onDelete }: Props)
       </td>
       <td className="t-list-cell t-list-cell--due">
         {task.dueDate ? (
-          <span className={overdue ? 't-overdue' : ''}>
+          <span
+            className={overdue ? 't-overdue' : ''}
+            aria-label={overdue ? `Overdue, ${formatDate(task.dueDate)}` : undefined}
+          >
             {overdue && <span className="t-overdue-icon" aria-hidden="true">!</span>}
             {formatDate(task.dueDate)}
           </span>

--- a/TaskFlow.Web/src/context/PrefsContext.tsx
+++ b/TaskFlow.Web/src/context/PrefsContext.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { loadPrefs, savePrefs, DEFAULT_PROJECT_START } from '@/lib/prefs'
-import type { SortMode, HeaderStyle } from '@/lib/prefs'
+import type { SortMode, HeaderStyle, TaskSortKey, TaskSortDir } from '@/lib/prefs'
 import { PrefsContext } from './PrefsContextDef'
 
 export function PrefsProvider({ children }: { children: React.ReactNode }) {
@@ -15,6 +15,12 @@ export function PrefsProvider({ children }: { children: React.ReactNode }) {
   const [todoSort, setTodoSort] = useState<SortMode>(() => initialPrefs.todoSort ?? 'manual')
   const [projectStart, setProjectStart] = useState<string>(
     () => initialPrefs.projectStart ?? DEFAULT_PROJECT_START,
+  )
+  const [taskSortKey, setTaskSortKey] = useState<TaskSortKey>(
+    () => initialPrefs.taskSortKey ?? 'title',
+  )
+  const [taskSortDir, setTaskSortDir] = useState<TaskSortDir>(
+    () => initialPrefs.taskSortDir ?? 'asc',
   )
 
   useEffect(() => {
@@ -36,6 +42,10 @@ export function PrefsProvider({ children }: { children: React.ReactNode }) {
     savePrefs({ headerStyle, todoSort, projectStart })
   }, [headerStyle, todoSort, projectStart])
 
+  useEffect(() => {
+    savePrefs({ taskSortKey, taskSortDir })
+  }, [taskSortKey, taskSortDir])
+
   return (
     <PrefsContext.Provider
       value={{
@@ -49,6 +59,10 @@ export function PrefsProvider({ children }: { children: React.ReactNode }) {
         setTodoSort,
         projectStart,
         setProjectStart,
+        taskSortKey,
+        setTaskSortKey,
+        taskSortDir,
+        setTaskSortDir,
       }}
     >
       {children}

--- a/TaskFlow.Web/src/context/PrefsContextDef.ts
+++ b/TaskFlow.Web/src/context/PrefsContextDef.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react'
-import type { SortMode, HeaderStyle } from '@/lib/prefs'
+import type { SortMode, HeaderStyle, TaskSortKey, TaskSortDir } from '@/lib/prefs'
 
 export interface PrefsContextValue {
   isDark: boolean
@@ -12,6 +12,10 @@ export interface PrefsContextValue {
   setTodoSort: (v: SortMode) => void
   projectStart: string
   setProjectStart: (v: string) => void
+  taskSortKey: TaskSortKey
+  setTaskSortKey: (v: TaskSortKey) => void
+  taskSortDir: TaskSortDir
+  setTaskSortDir: (v: TaskSortDir) => void
 }
 
 export const PrefsContext = createContext<PrefsContextValue | null>(null)

--- a/TaskFlow.Web/src/lib/prefs.ts
+++ b/TaskFlow.Web/src/lib/prefs.ts
@@ -3,6 +3,8 @@ export const DEFAULT_PROJECT_START = '2026-05-09'
 
 export type SortMode = 'manual' | 'open first' | 'done last'
 export type HeaderStyle = 'stat' | 'minimal'
+export type TaskSortKey = 'title' | 'dueDate' | 'priority' | 'status'
+export type TaskSortDir = 'asc' | 'desc'
 
 export interface Prefs {
   dark?: boolean
@@ -10,6 +12,8 @@ export interface Prefs {
   headerStyle?: HeaderStyle
   todoSort?: SortMode
   projectStart?: string
+  taskSortKey?: TaskSortKey
+  taskSortDir?: TaskSortDir
 }
 
 export function loadPrefs(): Prefs {

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -1,42 +1,74 @@
 import { useState } from 'react'
 import { useTasksQuery, useCreateTaskMutation, useUpdateTaskMutation, useDeleteTaskMutation } from '@/hooks/useTasks'
-import { TaskCard } from '@/components/TaskCard'
+import { useJournalEntries } from '@/hooks/useJournal'
+import { usePrefs } from '@/context/usePrefs'
+import { TaskListRow } from '@/components/TaskListRow'
 import { TaskForm } from '@/components/TaskForm'
 import type { TaskItemResponseDto, CreateTaskItemDto } from '@/api/client/types.gen'
+import type { TaskSortKey } from '@/lib/prefs'
+import type { JournalEntryResponseDto } from '@/api/journal'
+import { todayISO } from '@/lib/journal-utils'
 import '@/tasks.css'
 
 type StatusFilter = 'all' | 'draft' | 'todo' | 'completed'
 type PriorityFilter = 'all' | 'low' | 'medium' | 'high'
-type SortKey = 'title' | 'dueDate' | 'priority'
 
 const priorityOrder = { high: 0, medium: 1, low: 2 }
 
+interface ColHeader {
+  key: TaskSortKey
+  label: string
+}
+
+const COLUMNS: ColHeader[] = [
+  { key: 'title', label: 'Title' },
+  { key: 'status', label: 'Status' },
+  { key: 'priority', label: 'Priority' },
+  { key: 'dueDate', label: 'Due Date' },
+]
+
 export function TasksPage() {
   const { data, isLoading, error } = useTasksQuery()
+  const { data: journalData } = useJournalEntries()
   const createMutation = useCreateTaskMutation()
   const updateMutation = useUpdateTaskMutation()
   const deleteMutation = useDeleteTaskMutation()
+  const { taskSortKey, setTaskSortKey, taskSortDir, setTaskSortDir } = usePrefs()
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>('all')
-  const [sortKey, setSortKey] = useState<SortKey>('title')
   const [editingTask, setEditingTask] = useState<TaskItemResponseDto | null>(null)
   const [showCreate, setShowCreate] = useState(false)
 
   const tasks: TaskItemResponseDto[] = (data?.data as TaskItemResponseDto[] | undefined) ?? []
 
+  const todayEntry = ((journalData?.data as JournalEntryResponseDto[] | undefined) ?? [])
+    .find(e => e.date === todayISO())
+  const todayTaskIds = new Set<number>(todayEntry?.todoTaskItemIds ?? [])
+
+  function handleSortClick(key: TaskSortKey) {
+    if (key === taskSortKey) {
+      setTaskSortDir(taskSortDir === 'asc' ? 'desc' : 'asc')
+    } else {
+      setTaskSortKey(key)
+      setTaskSortDir('asc')
+    }
+  }
+
   const filtered = tasks
     .filter(t => statusFilter === 'all' || t.status?.toLowerCase() === statusFilter)
     .filter(t => priorityFilter === 'all' || t.priority?.toLowerCase() === priorityFilter)
     .sort((a, b) => {
-      if (sortKey === 'title') return a.title.localeCompare(b.title)
-      if (sortKey === 'dueDate') return (a.dueDate ?? '').localeCompare(b.dueDate ?? '')
-      if (sortKey === 'priority') {
+      let cmp = 0
+      if (taskSortKey === 'title') cmp = a.title.localeCompare(b.title)
+      else if (taskSortKey === 'dueDate') cmp = (a.dueDate ?? '').localeCompare(b.dueDate ?? '')
+      else if (taskSortKey === 'status') cmp = (a.status ?? '').localeCompare(b.status ?? '')
+      else if (taskSortKey === 'priority') {
         const pa = priorityOrder[(a.priority ?? '').toLowerCase() as keyof typeof priorityOrder] ?? 2
         const pb = priorityOrder[(b.priority ?? '').toLowerCase() as keyof typeof priorityOrder] ?? 2
-        return pa - pb
+        cmp = pa - pb
       }
-      return 0
+      return taskSortDir === 'asc' ? cmp : -cmp
     })
 
   function handleCreate(data: CreateTaskItemDto) {
@@ -55,6 +87,11 @@ export function TasksPage() {
     if (window.confirm(`Delete "${task.title}"?`)) {
       deleteMutation.mutate(Number(task.id))
     }
+  }
+
+  function sortIcon(key: TaskSortKey): string {
+    if (key !== taskSortKey) return ''
+    return taskSortDir === 'asc' ? ' ↑' : ' ↓'
   }
 
   if (isLoading) return <div className="tasks-page"><div className="t-shell"><p className="t-loading">Loading tasks…</p></div></div>
@@ -106,31 +143,42 @@ export function TasksPage() {
             <option value="high">High</option>
           </select>
 
-          <label htmlFor="sort-key" className="t-filter-label">Sort</label>
-          <select
-            id="sort-key"
-            className="t-select"
-            value={sortKey}
-            onChange={e => setSortKey(e.target.value as SortKey)}
-          >
-            <option value="title">Title</option>
-            <option value="dueDate">Due Date</option>
-            <option value="priority">Priority</option>
-          </select>
+          <span className="t-filter-count">{filtered.length} task{filtered.length !== 1 ? 's' : ''}</span>
         </div>
 
         {filtered.length === 0 ? (
           <p className="t-empty">No tasks match your filters.</p>
         ) : (
-          <div className="t-card-grid">
-            {filtered.map(task => (
-              <TaskCard
-                key={String(task.id)}
-                task={task}
-                onEdit={setEditingTask}
-                onDelete={handleDelete}
-              />
-            ))}
+          <div className="t-list-wrap">
+            <table className="t-list-table">
+              <thead>
+                <tr className="t-list-head-row">
+                  {COLUMNS.map(col => (
+                    <th
+                      key={col.key}
+                      className={`t-list-th t-col-sort${col.key === taskSortKey ? ' t-col-sort--active' : ''}`}
+                      onClick={() => handleSortClick(col.key)}
+                      aria-sort={col.key === taskSortKey ? (taskSortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                    >
+                      {col.label}{sortIcon(col.key)}
+                    </th>
+                  ))}
+                  <th className="t-list-th t-list-th--journal" title="On today's journal">Journal</th>
+                  <th className="t-list-th t-list-th--actions"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(task => (
+                  <TaskListRow
+                    key={String(task.id)}
+                    task={task}
+                    isOnTodayJournal={todayTaskIds.has(Number(task.id))}
+                    onEdit={setEditingTask}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -169,7 +169,7 @@ export function TasksPage() {
                     </th>
                   ))}
                   <th className="t-list-th t-list-th--journal" title="On today's journal">Journal</th>
-                  <th className="t-list-th t-list-th--actions"></th>
+                  <th className="t-list-th t-list-th--actions" aria-label="Actions"></th>
                 </tr>
               </thead>
               <tbody>

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -156,11 +156,16 @@ export function TasksPage() {
                   {COLUMNS.map(col => (
                     <th
                       key={col.key}
-                      className={`t-list-th t-col-sort${col.key === taskSortKey ? ' t-col-sort--active' : ''}`}
-                      onClick={() => handleSortClick(col.key)}
+                      className={`t-list-th${col.key === taskSortKey ? ' t-col-sort--active' : ''}`}
                       aria-sort={col.key === taskSortKey ? (taskSortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
                     >
-                      {col.label}{sortIcon(col.key)}
+                      <button
+                        type="button"
+                        className="t-col-sort-btn"
+                        onClick={() => handleSortClick(col.key)}
+                      >
+                        {col.label}{sortIcon(col.key)}
+                      </button>
                     </th>
                   ))}
                   <th className="t-list-th t-list-th--journal" title="On today's journal">Journal</th>

--- a/TaskFlow.Web/src/tasks.css
+++ b/TaskFlow.Web/src/tasks.css
@@ -164,6 +164,25 @@ html.is-dark .t-select { color-scheme: dark; }
   text-align: right;
 }
 
+
+.t-col-sort-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color .12s;
+}
+.t-list-th .t-col-sort-btn:hover { color: var(--ink); }
+.t-col-sort--active .t-col-sort-btn { color: var(--accent-ink); }
+
 .t-list-empty {
   color: var(--muted-2);
 }

--- a/TaskFlow.Web/src/tasks.css
+++ b/TaskFlow.Web/src/tasks.css
@@ -91,12 +91,119 @@
 .t-select:focus { border-color: var(--accent); }
 html.is-dark .t-select { color-scheme: dark; }
 
-/* ─── Task card grid ──────────────────────────────────────────────────────── */
+/* ─── Task list table ─────────────────────────────────────────────────────── */
 
-.t-card-grid {
-  display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+.t-list-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.t-list-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.t-list-head-row {
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+}
+
+.t-list-th {
+  padding: 10px 14px;
+  text-align: left;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.t-list-th--journal { width: 72px; text-align: center; }
+.t-list-th--actions { width: 120px; }
+
+.t-col-sort {
+  cursor: pointer;
+  transition: color .12s;
+}
+.t-col-sort:hover { color: var(--ink); }
+.t-col-sort--active { color: var(--accent-ink); }
+
+.t-list-row {
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--paper);
+  transition: background .1s;
+}
+.t-list-row:last-child { border-bottom: none; }
+.t-list-row:hover { background: var(--hover-soft); }
+
+.t-list-cell {
+  padding: 11px 14px;
+  vertical-align: middle;
+}
+
+.t-list-cell--title {
+  min-width: 200px;
+}
+
+.t-list-cell--due {
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+
+.t-list-cell--journal {
+  text-align: center;
+}
+
+.t-list-cell--actions {
+  text-align: right;
+}
+
+.t-list-empty {
+  color: var(--muted-2);
+}
+
+/* ─── Overdue indicator ───────────────────────────────────────────────────── */
+
+.t-overdue {
+  color: var(--danger-ink);
+  font-weight: 600;
+}
+
+.t-overdue-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--danger-bg);
+  color: var(--danger-ink);
+  font-size: 10px;
+  font-weight: 800;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+
+/* ─── Journal indicator ───────────────────────────────────────────────────── */
+
+.t-journal-dot {
+  font-size: 15px;
+  cursor: default;
+}
+
+/* ─── Filter count ────────────────────────────────────────────────────────── */
+
+.t-filter-count {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 
 /* ─── Task card ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
- New TaskListRow component: columns for Title, Status, Priority, Due Date (overdue highlight), Journal indicator (today's journal), and Edit/Delete actions
- TasksPage: click column headers to sort asc/desc; removed old Sort dropdown; added task count badge in filter bar; pulls today's journal entry from useJournalEntries to show journal indicator with no extra API requests
- Prefs: add taskSortKey + taskSortDir to Prefs interface, PrefsContext, and PrefsProvider so sort preference persists across sessions via localStorage
- tasks.css: add list table, overdue, journal dot, and filter count styles; preserve card styles for TaskCard (still used on detail page)