### PR TITLE
docs: archive Azure deployment references, update to Portainer GitOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TaskFlow
 
-A full-stack task management application demonstrating modern development practices and cloud deployment patterns. The project consists of a **production-ready .NET 10 REST API** and a **React TypeScript frontend**, both containerised and deployed to Azure.
+A full-stack task management application demonstrating modern development practices and containerized deployment patterns. The project consists of a **production-ready .NET 10 REST API** and a **React TypeScript frontend**, both containerised and deployed via Docker and Portainer GitOps.
 
-While functional as a task management system, this project serves as a portfolio piece showcasing professional engineering practices across the full stack — from API design and automated testing to CI/CD pipelines and cloud-native deployment.
+While functional as a task management system, this project serves as a portfolio piece showcasing professional engineering practices across the full stack — from API design and automated testing to CI/CD pipelines and on-premises Docker deployment.
 
 ## Overview
 
@@ -35,8 +35,9 @@ While functional as a task management system, this project serves as a portfolio
 
 **DevOps**
 - 🐳 Docker Compose for local full-stack development
-- ☁️ Azure deployment automation via GitHub Actions + OIDC (no stored credentials)
+- 🎯 Portainer GitOps deployment to on-premises Docker host
 - 🔁 CI pipeline: lint → type-check → test → build → smoke test (parallel API and Web jobs)
+- 📦 GitHub Container Registry (GHCR) for image hosting
 
 ## Quick Start
 
@@ -91,7 +92,7 @@ See **[Getting Started](docs/GETTING_STARTED.md)** for the full setup walkthroug
 - **[API Reference](docs/API.md)** — Complete endpoint documentation with examples
 - **[API Versioning](docs/API_VERSIONING.md)** — Versioning strategy and migration guide
 - **[Architecture](docs/ARCHITECTURE.md)** — Design decisions, patterns, and quality practices
-- **[Deployment](docs/DEPLOYMENT.md)** — Docker, Azure, and CI/CD workflows
+- **[Deployment](docs/DEPLOYMENT.md)** — Docker, Portainer GitOps, and CI/CD workflows
 - **[Contributing](docs/CONTRIBUTING.md)** — Development workflow and standards
 
 ### Reference Documentation
@@ -99,9 +100,7 @@ See **[Getting Started](docs/GETTING_STARTED.md)** for the full setup walkthroug
 - **[Docker Configuration](docs/DOCKER_CONFIGURATION.md)** — Dev vs prod Docker comparison (all three services)
 - **[Volumes](docs/VOLUMES.md)** — Volume configuration and persistence
 - **[Health Checks](docs/HEALTH_CHECK_TESTING.md)** — Health check setup and testing
-- **[Azure OIDC](docs/AZURE_OIDC_AUTHENTICATION.md)** — Azure authentication setup
-- **[QA Deployment](docs/QA_DEPLOYMENT.md)** — Ephemeral QA environments
-- **[Resource Naming](docs/DEPLOY.md)** — Azure naming standards
+- **[Image & Deployment Naming](docs/DEPLOY.md)** — GHCR image tagging and deployment conventions
 - **[Service Registration](docs/SERVICE_REGISTRATION_PATTERN.md)** — .NET DI extension pattern
 - **[Security Scanning](docs/SECURITY_SCANNING.md)** — CodeQL and Trivy
 - **[Logging](docs/LOGGING.md)** — OpenTelemetry configuration

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ TaskFlow/
 | Observability | OpenTelemetry (traces, metrics, logs → Seq) |
 | API docs | OpenAPI + Scalar UI |
 | Testing | xUnit, Moq, FluentAssertions, Coverlet |
-| Deployment | Docker, Azure Container Instances (ACI) |
+| Deployment | Docker, Portainer GitOps |
 | CI/CD | GitHub Actions |
 
 ### Frontend
@@ -181,7 +181,7 @@ If you're evaluating this project for hiring or collaboration, here's what to lo
 ### DevOps & Deployment
 - **Multi-stage Docker builds** — optimised production images for both API and frontend
 - **GitHub Actions workflows** — parallel CI jobs for API and frontend (lint, type-check, test, build, smoke test)
-- **Azure deployment via OIDC** — no stored credentials; federated identity with Azure
+- **Portainer GitOps deployment** — images in GHCR, configuration in separate `nevridge/taskflow-deploy` repo, automatic Portainer redeploys
 - **Environment-specific configuration** — `.env.development` / `.env.production` for frontend; `appsettings.*.json` and env vars for the API
 
 ### Testing & Quality

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,11 +8,9 @@ Complete reference for TaskFlow.Api REST endpoints.
 - Direct run: `https://localhost:{port}` (port shown in console)
 - Docker: `http://localhost:8080`
 
-**Azure Production:**
-- `https://nevridge-taskflow-prod-web.azurewebsites.net`
-
-**Azure QA:**
-- `http://taskflow-qa.eastus.azurecontainer.io:8080`
+**Production:**
+- API: `https://taskflow-api.skalaforge.com`
+- Web: `https://taskflow.skalaforge.com`
 
 ## Authentication
 

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -212,8 +212,8 @@ Test both URL versioning (`/api/v1/TaskItems`) and header versioning (`x-api-ver
 
 - [Microsoft API Versioning GitHub](https://github.com/dotnet/aspnet-api-versioning)
 - [Microsoft Learn: API Versioning](https://learn.microsoft.com/en-us/aspnet/core/web-api/advanced/versioning)
-- [Azure API Design Best Practices](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design#versioning)
 - [RESTful API Design Guidelines](https://restfulapi.net/versioning/)
+- [Semantic Versioning](https://semver.org/)
 
 ## Summary
 

--- a/docs/AZURE_OIDC_AUTHENTICATION.md
+++ b/docs/AZURE_OIDC_AUTHENTICATION.md
@@ -41,48 +41,22 @@ For current deployment procedures, refer to:
 
 ---
 
-**Archive Note:** The original Azure OIDC setup enabled GitHub Actions to authenticate directly to Azure services without storing credentials. This approach was used when deployments targeted Azure App Service and Container Instances. The current on-premises deployment model simplifies authentication by using GitHub's built-in GITHUB_TOKEN for GHCR and a simple PAT for the GitOps repository.
+## Legacy Azure OIDC Instructions (ARCHIVED)
 
-- `AZURE_CLIENT_ID` - The `appId` from step 1
-- `AZURE_TENANT_ID` - The `tenant` from step 1
-- `AZURE_SUBSCRIPTION_ID` - Run `az account show --query id -o tsv`
+> **⚠️ Do not follow these instructions.** Azure OIDC authentication is no longer used. The sections below are retained for historical reference only.
 
-### 4. Configure GitHub Environments
+The following sections describe how the legacy Azure OIDC authentication workflow was configured. These instructions should not be used for any new deployments.
 
-Create GitHub Environments that match the federated credential subjects. In GitHub repository **Settings → Environments**, create:
+For current GitHub Actions authentication procedures, see [DEPLOY.md](DEPLOY.md) which covers the current GITHUB_TOKEN and DEPLOY_REPO_TOKEN setup.
 
-- `qa` - For QA deployments
-- `production` - For production deployments
+---
 
-**Important**: The environment names must exactly match the subjects configured in step 2:
-- QA subject: `repo:nevridge/TaskFlow.Api:environment:qa`
-- Production subject: `repo:nevridge/TaskFlow.Api:environment:production`
+### Legacy: Azure Service Principal Setup
 
-The workflows reference these environments:
-- `.github/workflows/qa-deploy.yaml` uses `environment: qa`
-- `.github/workflows/prod-deploy.yaml` uses `environment: production`
-- `.github/workflows/prod-teardown.yaml` uses `environment: production`
+*This section is archived. Azure authentication is no longer needed.*
 
-### 5. Verify Workflows
-
-The workflows in this repository already have the correct configuration:
-- `permissions.id-token: write` is set (required for OIDC)
-- `azure/login@v2` uses individual parameters (not JSON creds)
-- Each workflow specifies the appropriate `environment` that matches the federated credential subject
-
-## Common Issues
-
-**"AADSTS70021: No matching federated identity record found"**
-- Verify the subject claim matches your repository name exactly
-- Check federated credentials: `az ad app federated-credential list --id $(az ad app list --display-name "TaskFlowGitHubActions" --query "[0].appId" -o tsv)`
-
-**"ClientAuthenticationFailed"**
-- Ensure workflow has `permissions.id-token: write`
-
-**"The subscription ... could not be found"**
-- Verify service principal has Contributor role: `az role assignment list --assignee $(az ad app list --display-name "TaskFlowGitHubActions" --query "[0].appId" -o tsv)`
-
-## Additional Resources
-
-- [GitHub Docs - OIDC in Azure](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure)
-- [Azure Workload Identity Federation](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation)
+The Azure OIDC setup previously required:
+- Azure service principals
+- Azure CLI commands
+- Azure OIDC federated credentials
+- `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` GitHub secrets (now removed)

--- a/docs/AZURE_OIDC_AUTHENTICATION.md
+++ b/docs/AZURE_OIDC_AUTHENTICATION.md
@@ -1,53 +1,47 @@
-# Azure OIDC Authentication Setup
+# Azure OIDC Authentication Setup (ARCHIVED)
 
-This guide covers how to set up Azure authentication for TaskFlow.Api GitHub Actions using OpenID Connect (OIDC) with federated credentials. This replaces the deprecated `--sdk-auth` method and eliminates the need to store client secrets.
+> **⚠️ Deprecated** — This document describes the legacy Azure authentication setup which has been archived.
+>
+> TaskFlow now deploys to on-premises infrastructure using Docker and Portainer GitOps. GitHub Actions workflows use the automatic `GITHUB_TOKEN` environment variable to push images to GitHub Container Registry (GHCR).
 
-## Prerequisites
+## Legacy Azure Authentication
 
-- Azure subscription with permissions to create service principals
-- Azure CLI installed
-- Contributor or Owner role on the Azure subscription or resource group
+This file is retained for reference only. The Azure OIDC authentication workflow has been replaced with a simpler GitHub Actions approach that uses GHCR for image hosting.
 
-## Quick Setup
+### What Changed
 
-### 1. Create Service Principal
+- **Previous:** GitHub Actions authenticated to Azure using OIDC with federated credentials
+- **Current:** GitHub Actions use the automatic `GITHUB_TOKEN` to push images to GHCR; no Azure authentication needed
 
-```bash
-az ad sp create-for-rbac \
-  --name "TaskFlowGitHubActions" \
-  --role contributor \
-  --scopes /subscriptions/YOUR_SUBSCRIPTION_ID
+### Migration Notes
+
+- **Removed:** Azure service principals, Azure CLI commands, Azure OIDC federated credentials
+- **Removed:** `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` GitHub secrets
+- **Added:** `DEPLOY_REPO_TOKEN` GitHub secret for updating the `nevridge/taskflow-deploy` repository
+- **Deployment Method:** Portainer GitOps with images from GitHub Container Registry (GHCR)
+
+### Current Authentication Flow
+
+```
+Push to main (TaskFlow repo)
+    ↓
+GitHub Actions builds images
+    ↓
+Push to GHCR (using automatic GITHUB_TOKEN)
+    ↓
+Update taskflow-deploy repo (using DEPLOY_REPO_TOKEN)
+    ↓
+Portainer detects change and deploys
 ```
 
-Save the output - you'll need `appId` (client ID) and `tenant` (tenant ID).
+For current deployment procedures, refer to:
+- [DEPLOY.md](DEPLOY.md) — Image naming and deployment conventions
+- [Deployment Guide](DEPLOYMENT.md) — Full deployment walkthrough
+- [Docker Configuration](DOCKER_CONFIGURATION.md) — Docker Compose setup
 
-### 2. Configure Federated Credentials
+---
 
-Replace `nevridge/TaskFlow.Api` with your repository if different:
-
-```bash
-APP_ID=$(az ad app list --display-name "TaskFlowGitHubActions" --query "[0].appId" -o tsv)
-
-# For QA environment deployments
-az ad app federated-credential create --id $APP_ID --parameters '{
-  "name": "TaskFlowQA",
-  "issuer": "https://token.actions.githubusercontent.com",
-  "subject": "repo:nevridge/TaskFlow.Api:environment:qa",
-  "audiences": ["api://AzureADTokenExchange"]
-}'
-
-# For production environment deployments
-az ad app federated-credential create --id $APP_ID --parameters '{
-  "name": "TaskFlowProduction",
-  "issuer": "https://token.actions.githubusercontent.com",
-  "subject": "repo:nevridge/TaskFlow.Api:environment:production",
-  "audiences": ["api://AzureADTokenExchange"]
-}'
-```
-
-### 3. Add GitHub Secrets
-
-In GitHub repository **Settings → Secrets and variables → Actions**, add:
+**Archive Note:** The original Azure OIDC setup enabled GitHub Actions to authenticate directly to Azure services without storing credentials. This approach was used when deployments targeted Azure App Service and Container Instances. The current on-premises deployment model simplifies authentication by using GitHub's built-in GITHUB_TOKEN for GHCR and a simple PAT for the GitOps repository.
 
 - `AZURE_CLIENT_ID` - The `appId` from step 1
 - `AZURE_TENANT_ID` - The `tenant` from step 1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -472,7 +472,7 @@ When updating documentation:
 | `README.md` | Overview, quick start, highlights | Everyone |
 | `GETTING_STARTED.md` | Detailed setup instructions | Developers |
 | `ARCHITECTURE.md` | Design decisions, patterns | Developers, Reviewers |
-| `DEPLOYMENT.md` | Docker, Azure, CI/CD | DevOps, Developers |
+| `DEPLOYMENT.md` | Docker, Portainer GitOps, CI/CD | DevOps, Developers |
 | `API.md` | Endpoint reference | Developers, API Users |
 | `CONTRIBUTING.md` | Development workflow | Contributors |
 | `SECURITY_SCANNING.md` | CodeQL, Trivy setup | DevOps, Security |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,273 +1,54 @@
-# Azure Resource Naming Convention
+# GHCR Image & Deployment Naming
 
-> **📖 Reference Documentation** - This document details Azure resource naming standards. For deployment instructions, see the [Deployment Guide](DEPLOYMENT.md).
+> **📖 Reference Documentation** — Image naming and deployment conventions for TaskFlow. For deployment instructions, see the [Deployment Guide](DEPLOYMENT.md).
 
+TaskFlow uses GitHub Container Registry (GHCR) to host production Docker images and Portainer GitOps to deploy them.
 
-This document defines the standardized naming convention for all Azure resources deployed by TaskFlow.Api workflows.
+## Image Naming
 
-## Overview
+All production images are pushed to GHCR under the `nevridge` organisation:
 
-Consistent resource naming improves:
-- **Discoverability**: Easy to identify resources and their purpose
-- **Automation**: Predictable names enable scripting and automation
-- **Cost Management**: Clear resource ownership and environment tracking
-- **Compliance**: Adherence to organizational standards
+| Image | GHCR Path |
+|-------|-----------|
+| API | `ghcr.io/nevridge/taskflow-api` |
+| Web | `ghcr.io/nevridge/taskflow-web` |
 
-## Naming Convention
+### Tagging Strategy
 
-All resources follow the pattern: `{org}-{app}-{env}-{resourceType}` with the following components:
+Each production build produces two tags:
 
-- **{org}**: Organization identifier (`nevridge`)
-- **{app}**: Application name (`taskflow`)
-- **{env}**: Environment (`prod`, `qa`, `dev`)
-- **{resourceType}**: Resource type identifier (see table below)
+| Tag | Example | Purpose |
+|-----|---------|---------|
+| `sha-<commit>` | `sha-a1b2c3d` | Immutable tag for this exact build |
+| `latest` | `latest` | Mutable pointer to the most recent build |
 
-### Resource Type Suffixes
+The `sha-<commit>` tag is what the `nevridge/taskflow-deploy` GitOps repository pins to, ensuring rollbacks are safe and point to an exact build.
 
-| Resource Type | Suffix/Pattern | Example |
-|---------------|----------------|---------|
-| Resource Group | `-rg` | `nevridge-taskflow-prod-rg` |
-| Azure Container Instance | `-aci` | `nevridge-taskflow-qa-aci` |
-| App Service | `-web` | `nevridge-taskflow-prod-web` |
-| App Service Plan | `-plan` | `nevridge-taskflow-prod-plan` |
-| Container Registry | `{org}{app}{env}acr` | `nevridgetaskflowprodacr` |
-| Storage Account | `{org}{app}{env}st{nn}` | `nevridgetaskflowqast01` |
+## Deployment Repository
 
-### Special Cases
+Production configuration lives in a separate repository: [nevridge/taskflow-deploy](https://github.com/nevridge/taskflow-deploy)
 
-#### Container Registry (ACR)
-ACR names must be globally unique and can only contain alphanumeric characters (no hyphens). Pattern: `{org}{app}{env}acr`
+The `ghcr-deploy.yml` workflow updates image tags in that repo on every push to `main`. Portainer polls for changes and redeploys the stack automatically.
 
-**Examples:**
-- Production: `nevridgetaskflowprodacr`
-- QA: `nevridgetaskflowqaacr`
+## Environment Naming
 
-#### Storage Accounts
-Storage account names must be globally unique, 3-24 characters, lowercase alphanumeric only. Pattern: `{org}{app}{env}st{nn}` where {nn} is a two-digit sequence number.
+| Environment | Description | Access |
+|-------------|-------------|--------|
+| Production | Live deployment on Docker host via Portainer | `taskflow.skalaforge.com` / `taskflow-api.skalaforge.com` |
+| Development | Local Docker Compose | `http://localhost:8080` |
 
-**Examples:**
-- Production: `nevridgetaskflowprodst01`
-- QA: `nevridgetaskflowqast01`
+## Required Secrets
 
-#### DNS Labels
-DNS name labels for Azure Container Instances should be predictable for QA/testing environments. Pattern: `{app}-{env}`
-
-**Examples:**
-- QA: `taskflow-qa` → Full DNS: `taskflow-qa.{region}.azurecontainer.io`
-- Staging: `taskflow-staging` → Full DNS: `taskflow-staging.{region}.azurecontainer.io`
-
-## Azure Naming Constraints
-
-### General Rules
-- **Length**: Most resources support 1-80 characters
-- **Characters**: Alphanumeric, hyphens, and underscores (varies by resource type)
-- **Case**: Some resources are case-insensitive (e.g., storage accounts, ACR)
-
-### Resource-Specific Constraints
-
-| Resource Type | Length | Valid Characters | Case | Globally Unique |
-|---------------|--------|-----------------|------|-----------------|
-| Resource Group | 1-90 | Alphanumeric, underscore, hyphen, period, parentheses | Insensitive | Within subscription |
-| ACI | 1-63 | Alphanumeric, hyphen | Insensitive | Within resource group |
-| ACR | 5-50 | Alphanumeric only | Insensitive | Global |
-| DNS Label | 1-63 | Alphanumeric, hyphen (not at start/end) | Insensitive | Per region |
-| Storage Account | 3-24 | Lowercase alphanumeric only | Insensitive | Global |
-
-## Workflow Implementation
-
-### Environment Variables
-
-Both production and QA workflows define the following centralized environment variables:
-
-```yaml
-env:
-  ORG_NAME: nevridge
-  APP_NAME: taskflow
-  ENV: prod  # or 'qa' for QA workflow
-  LOCATION: eastus
-```
-
-### Computed Resource Names
-
-Workflows compute resource names from these base variables:
-
-```yaml
-- name: Compute resource names
-  run: |
-    # Base components
-    ORG="${{ env.ORG_NAME }}"
-    APP="${{ env.APP_NAME }}"
-    ENV="${{ env.ENV }}"
-    
-    # Computed names
-    RG_NAME="${ORG}-${APP}-${ENV}-rg"
-    ACI_NAME="${ORG}-${APP}-${ENV}-aci"
-    DNS_NAME_LABEL="${APP}-${ENV}"
-    
-    # Special: ACR (no hyphens, alphanumeric only)
-    ACR_NAME="${ORG}${APP}${ENV}acr"
-    
-    # Export to environment
-    echo "RG_NAME=$RG_NAME" >> $GITHUB_ENV
-    echo "ACI_NAME=$ACI_NAME" >> $GITHUB_ENV
-    echo "DNS_NAME_LABEL=$DNS_NAME_LABEL" >> $GITHUB_ENV
-    echo "ACR_NAME=$ACR_NAME" >> $GITHUB_ENV
-    
-    # Log computed names
-    echo "Computed resource names:"
-    echo "  Resource Group: $RG_NAME"
-    echo "  ACI Container: $ACI_NAME"
-    echo "  DNS Label: $DNS_NAME_LABEL"
-    echo "  ACR: $ACR_NAME"
-```
-
-### Validation Step
-
-Workflows include a validation step to check Azure naming constraints:
-
-```yaml
-- name: Validate resource names
-  run: |
-    # Function to validate length
-    validate_length() {
-      local name=$1
-      local min=$2
-      local max=$3
-      local resource=$4
-      local len=${#name}
-      if [ $len -lt $min ] || [ $len -gt $max ]; then
-        echo "ERROR: $resource name '$name' length ($len) must be between $min and $max characters"
-        exit 1
-      fi
-    }
-    
-    # Function to validate characters
-    validate_alphanumeric() {
-      local name=$1
-      local resource=$2
-      if ! [[ "$name" =~ ^[a-z0-9]+$ ]]; then
-        echo "ERROR: $resource name '$name' must contain only lowercase alphanumeric characters"
-        exit 1
-      fi
-    }
-    
-    # Validate ACR name
-    validate_length "$ACR_NAME" 5 50 "ACR"
-    validate_alphanumeric "$ACR_NAME" "ACR"
-    
-    # Validate DNS label
-    validate_length "$DNS_NAME_LABEL" 1 63 "DNS Label"
-    if ! [[ "$DNS_NAME_LABEL" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
-      echo "ERROR: DNS Label '$DNS_NAME_LABEL' must start and end with alphanumeric, can contain hyphens"
-      exit 1
-    fi
-    
-    echo "All resource names passed validation"
-```
-
-## QA Environment Specifics
-
-### Fixed DNS Label
-
-The QA environment uses a fixed DNS label (`taskflow-qa`) to provide a predictable endpoint for testing:
-
-- **DNS Label**: `taskflow-qa`
-- **Full DNS**: `taskflow-qa.eastus.azurecontainer.io` (example for East US)
-- **API Endpoint**: `http://taskflow-qa.eastus.azurecontainer.io:8080`
-- **Health Check**: `http://taskflow-qa.eastus.azurecontainer.io:8080/health`
-
-### Pre-deployment Cleanup
-
-The QA workflow includes a pre-deployment cleanup step to remove existing containers with the same DNS label:
-
-```yaml
-- name: Delete existing ACI if it exists
-  run: |
-    echo "Checking for existing ACI container: $ACI_NAME"
-    if az container show -g $RG_NAME -n $ACI_NAME >/dev/null 2>&1; then
-      echo "Deleting existing container to free DNS label..."
-      az container delete -g $RG_NAME -n $ACI_NAME --yes
-      # Wait for deletion to complete
-      for i in {1..30}; do
-        if ! az container show -g $RG_NAME -n $ACI_NAME >/dev/null 2>&1; then
-          echo "Container deletion confirmed"
-          break
-        fi
-        sleep 2
-      done
-    else
-      echo "No existing container found"
-    fi
-```
-
-## Production Environment Specifics
-
-### ACI Naming
-
-Production uses Azure Container Instances (ACI), consistent with the QA environment:
-
-- **Resource Group**: `nevridge-taskflow-prod-rg`
-- **ACI Container**: `nevridge-taskflow-prod-aci`
-- **DNS Label**: `taskflow-prod`
-- **ACR**: `nevridgetaskflowprodacr`
-- **Public URL**: `http://taskflow-prod.eastus.azurecontainer.io:8080`
-
-## Migration from Legacy Names
-
-If you are migrating from legacy resource names, follow these steps:
-
-### Option 1: Clean Deployment (Recommended for QA/Dev)
-
-1. Delete existing resources:
-   ```bash
-   az group delete -n OldResourceGroup --yes
-   ```
-
-2. Run workflow with new naming convention
-
-### Option 2: Gradual Migration (Recommended for Production)
-
-1. Create new resources alongside old ones
-2. Test thoroughly with new resources
-3. Update DNS/routing to point to new resources
-4. Decommission old resources after validation
-
-### Example Legacy to New Mapping
-
-| Old Name | New Name | Resource Type |
-|----------|----------|---------------|
-| `TaskFlowRG` | `nevridge-taskflow-prod-rg` | Resource Group |
-| `taskflowapi2074394909` | `nevridge-taskflow-prod-aci` | ACI Container (was Web App) |
-| `taskflowregistry` | `nevridgetaskflowprodacr` | ACR |
-| `taskflowapi` | `taskflowapi` | ACR Image Name |
-| `TaskFlowAppServicePlan` | *(removed)* | App Service Plan (no longer used) |
-| `taskflow-qa` (ACI) | `nevridge-taskflow-qa-aci` | Container Instance |
-
-## Best Practices
-
-1. **Always use computed names**: Never hard-code resource names directly in workflow steps
-2. **Log computed names**: Always log the computed names at the start of deployment for debugging
-3. **Validate early**: Run validation before creating any resources to fail fast
-4. **Document changes**: Update this document when adding new resource types
-5. **Test in QA**: Always test naming changes in QA environment before applying to production
-6. **Preserve DNS labels**: For QA environments, keep DNS labels consistent across deployments
-
-## References
-
-- [Azure Naming Rules and Restrictions](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)
-- [Azure Cloud Adoption Framework - Naming Convention](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging)
-- [Azure Container Instances Documentation](https://learn.microsoft.com/en-us/azure/container-instances/)
-- [Azure App Service Documentation](https://learn.microsoft.com/en-us/azure/app-service/)
-
-## Workflow Files
-
-- Production: `.github/workflows/prod-deploy.yaml`
-- QA: `.github/workflows/qa-deploy.yaml`
+| Secret | Location | Purpose |
+|--------|----------|---------|
+| `DEPLOY_REPO_TOKEN` | TaskFlow repo Actions secrets | PAT with `Contents: write` on `nevridge/taskflow-deploy` |
+| `GITHUB_TOKEN` | Automatic (GitHub Actions) | Push images to GHCR (`packages: write`) |
+| Portainer registry credential | Portainer UI | PAT with `read:packages` to pull images from GHCR |
 
 ## Related Documentation
 
-- [QA Deployment Guide](./QA_DEPLOYMENT.md)
-- [Main README](../README.md)
+- [Deployment Guide](DEPLOYMENT.md) — Full deployment walkthrough
+- [Docker Configuration](DOCKER_CONFIGURATION.md) — Docker Compose setup and configuration
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -408,7 +408,7 @@ See [Frontend Guide](FRONTEND.md) for the full frontend reference.
 - **Explore the UI:** http://localhost:5173 (dev) or http://localhost:3000 (Docker)
 - **Explore the API:** Scalar UI at http://localhost:8080/scalar/v1
 - **Review the code:** [Architecture](ARCHITECTURE.md) for design decisions
-- **Deploy to Azure:** [Deployment Guide](DEPLOYMENT.md)
+- **Deploy to production:** [Deployment Guide](DEPLOYMENT.md) — Portainer GitOps setup
 - **Run tests:** `dotnet test` and `cd TaskFlow.Web && npm run test -- --run`
 - **Add features:** [Contributing Guide](CONTRIBUTING.md)
 

--- a/docs/HEALTH_CHECK_TESTING.md
+++ b/docs/HEALTH_CHECK_TESTING.md
@@ -11,7 +11,7 @@ The health check configurations have been designed to accommodate database migra
 
 - **Docker Compose**: `start_period: 40s`
 - **Kubernetes**: `initialDelaySeconds: 45s` (readiness), `60s` (liveness)
-- **Azure App Service**: Built-in grace period + workflow verification with 30s initial delay
+- **Docker Host (Portainer)**: Uses same Docker Compose configuration
 
 ## Testing Docker Compose Health Checks
 
@@ -153,66 +153,39 @@ kubectl set env deployment/taskflow-api ConnectionStrings__DefaultConnection="in
 - **Cause**: Readiness probe `initialDelaySeconds` too long
 - **Solution**: Decrease slightly, but ensure migrations complete first
 
-## Testing Azure App Service Health Checks
+## Testing Docker Host (Portainer) Health Checks
 
-### Prerequisites
-- Azure subscription
-- Azure CLI installed and logged in
-- Deployment workflow successfully run
+> **Note:** Docker Host deployments use the same Docker Compose health check configuration as local development.
 
-### Test Procedure
+### Verification in Production
 
-1. **Verify health check configuration**:
-   ```bash
-   az webapp config show \
-     --resource-group <your-resource-group> \
-     --name <your-webapp-name> \
-     --query 'healthCheckPath'
-   ```
-   **Expected output**: `"/health"`
-
-2. **Monitor during deployment**:
-   - Go to GitHub Actions and trigger the deployment workflow
-   - Watch the "Verify health check" step output
-   - Should see initial 30 second wait, then health check attempts
-
-3. **Check App Service health in Azure Portal**:
-   - Navigate to your App Service
-   - Go to **Health check** under Monitoring
-   - View health check history and status
-
-4. **Manual health check**:
-   ```bash
-   curl https://<your-webapp-name>.azurewebsites.net/health
-   ```
-
-### Test Scenarios
-
-#### Scenario 1: Deploy with clean database
 ```bash
-# Clear database from Azure Portal or using Azure CLI
-# Then trigger deployment
-git tag -a v1.0.1 -m "Test deployment"
-git push origin v1.0.1
-```
-**Expected**: Workflow waits 30s, then successfully verifies health within 10 attempts (50s)
+# SSH to the Docker Host
+ssh user@docker-host
 
-#### Scenario 2: Monitor continuous health checks
-```bash
-# Continuously monitor health endpoint
-watch -n 5 'curl -s -o /dev/null -w "%{http_code}\n" https://<your-webapp-name>.azurewebsites.net/health'
+# Check container health
+docker ps --filter "name=taskflow-api" --format "table {{.Names}}\t{{.Status}}"
+
+# View health check details
+docker inspect --format '{{.State.Health.Status}}' taskflow-api
+
+# Manual health check
+curl https://taskflow-api.skalaforge.com/health
 ```
-**Expected**: Should return 200 consistently after initial startup period
+
+### Monitoring via Portainer
+
+1. **Access Portainer UI**
+2. **Navigate to Containers**
+3. **Find taskflow-api container**
+4. **Check Health column** - Should show "healthy"
 
 ### Troubleshooting
 
-**Problem**: Workflow health verification fails
-- **Cause**: App not ready within 30s initial delay + 10 retries
-- **Solution**: Increase sleep time or retry count in workflow
-
-**Problem**: Azure marks instance as unhealthy
-- **Cause**: Health check path not configured or migrations taking too long
-- **Solution**: Verify health check path configuration and check App Service logs
+**Problem**: Container shows "unhealthy"
+- **Check logs**: `docker logs taskflow-api`
+- **Verify DB connection**: Ensure volume mounts are correct
+- **Check network**: Ensure container can reach database
 
 ## General Testing Best Practices
 
@@ -241,15 +214,6 @@ readinessProbe:
   initialDelaySeconds: 45  # Adjust based on testing
 livenessProbe:
   initialDelaySeconds: 60  # Should be >= readiness + buffer
-```
-
-### Azure Workflow
-Edit `.github/workflows/prod-deploy.yaml`:
-```yaml
-- name: Verify health check
-  run: |
-    sleep 30  # Adjust based on testing
-    # ... retry logic
 ```
 
 ## Monitoring in Production

--- a/docs/HEALTH_CHECK_TESTING.md
+++ b/docs/HEALTH_CHECK_TESTING.md
@@ -163,11 +163,11 @@ kubectl set env deployment/taskflow-api ConnectionStrings__DefaultConnection="in
 # SSH to the Docker Host
 ssh user@docker-host
 
-# Check container health
-docker ps --filter "name=taskflow-api" --format "table {{.Names}}\t{{.Status}}"
+# Check container health (production container is named taskflow-api-prod)
+docker ps --filter "name=taskflow-api-prod" --format "table {{.Names}}\t{{.Status}}"
 
 # View health check details
-docker inspect --format '{{.State.Health.Status}}' taskflow-api
+docker inspect --format '{{.State.Health.Status}}' taskflow-api-prod
 
 # Manual health check
 curl https://taskflow-api.skalaforge.com/health

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -114,8 +114,8 @@ docker logs <container-name> | grep "Health check FAILED"
 All logs are exported via OTLP and can be directed to any compatible backend by changing the `OpenTelemetry__Endpoint` setting:
 
 - **Seq**: Default configuration targets `http://localhost:5341/ingest/otlp`
-- **Azure Monitor / Application Insights**: Use the `Azure.Monitor.OpenTelemetry.AspNetCore` package or configure the OTLP endpoint
 - **Grafana / Loki**: Point the endpoint at your Loki OTLP receiver
+- **Any OTLP-compatible backend**: Configure the endpoint in your environment
 
 Configure alerts for health check failures by filtering on "Health check FAILED" log messages in your chosen backend.
 

--- a/docs/QA_DEPLOYMENT.md
+++ b/docs/QA_DEPLOYMENT.md
@@ -1,103 +1,27 @@
-# QA Deployment Guide
+# QA Deployment Guide (ARCHIVED)
 
-> **📖 Reference Documentation** - This is a detailed QA deployment guide. For general deployment, see the [Deployment Guide](DEPLOYMENT.md).
+> **⚠️ Deprecated** — This document describes the legacy Azure Container Instances (ACI) QA deployment workflow which has been archived.
+>
+> TaskFlow now uses a unified **Portainer GitOps deployment pattern** for all environments. See [DEPLOY.md](DEPLOY.md) and [Deployment Guide](DEPLOYMENT.md) for current deployment information.
 
+## Legacy Azure QA Environment
 
-This document provides detailed information about the TaskFlow.Api QA deployment workflow using Azure Container Instances (ACI) with a fixed DNS name.
+This file is retained for reference only. The ephemeral QA deployment on Azure Container Instances has been replaced with a production-style deployment using Docker and Portainer on an on-premises Docker host.
 
-## Overview
+### Migration Notes
 
-The ephemeral QA deployment workflow creates a predictable test environment using Azure Container Instances. Unlike typical ephemeral deployments that use unique DNS names, this workflow uses a **fixed DNS name label** (`taskflow-qa`) to provide a consistent endpoint for QA testing.
+- **Previous QA Endpoint:** `http://taskflow-qa.eastus.azurecontainer.io:8080` (no longer active)
+- **Current Production Endpoint:** `https://taskflow-api.skalaforge.com` and `https://taskflow.skalaforge.com`
+- **Deployment Method:** Portainer GitOps with images from GitHub Container Registry (GHCR)
 
-## Key Features
+For current deployment procedures, refer to:
+- [Deployment Guide](DEPLOYMENT.md) — Full deployment walkthrough
+- [DEPLOY.md](DEPLOY.md) — Image naming and deployment naming conventions
+- [Docker Configuration](DOCKER_CONFIGURATION.md) — Docker Compose setup
 
-### Fixed DNS Name
+---
 
-The QA environment uses a **standardized naming convention** for all Azure resources. See [DEPLOY.md](DEPLOY.md) for complete details.
-
-**QA Resource Names**:
-- **Resource Group**: `nevridge-taskflow-qa-rg`
-- **Container Registry**: `nevridgetaskflowqaacr`
-- **ACI Container**: `nevridge-taskflow-qa-aci`
-- **DNS Name Label**: `taskflow-qa`
-
-**QA Endpoint Details**:
-- **DNS Name Label**: `taskflow-qa`
-- **Full DNS Format**: `taskflow-qa.{region}.azurecontainer.io`
-- **Port**: 8080
-- **Example URLs**:
-  - API Endpoint (East US): `http://taskflow-qa.eastus.azurecontainer.io:8080`
-  - Health Check (East US): `http://taskflow-qa.eastus.azurecontainer.io:8080/health`
-
-### Automatic Deployment Management
-
-The workflow automatically handles conflicts by:
-1. Checking if a container with the name `taskflow-qa` already exists in the resource group
-2. Deleting the existing container if found (to free up the DNS name)
-3. Creating a new container with the same fixed DNS name
-4. Verifying the deployment via health check
-
-This ensures that:
-- The QA endpoint always uses the same predictable URL
-- Previous deployments are automatically replaced without manual intervention
-- DNS conflicts are avoided
-- Each deployment serves the latest version of the application
-
-## Workflow Configuration
-
-### Workflow File
-`.github/workflows/qa-deploy.yaml`
-
-### Trigger Method
-Manual trigger via GitHub Actions workflow_dispatch
-
-### Input Parameters
-
-| Parameter | Description | Required | Default |
-|-----------|-------------|----------|---------|
-| `action` | Deploy or teardown the environment | Yes | `deploy` |
-| `resource_group` | Azure resource group name (overrides computed name) | No | `nevridge-taskflow-qa-rg` (computed) |
-| `location` | Azure region for deployment | No | `eastus` |
-| `acr_name` | Azure Container Registry name (overrides computed name) | No | `nevridgetaskflowqaacr` (computed) |
-| `image_tag` | Docker image tag to deploy | No | `latest` |
-
-### Environment Variables Set by Workflow
-
-The workflow follows the [Resource Naming Convention](DEPLOY.md) and computes resource names automatically.
-
-| Variable | Computed Value | Description |
-|----------|----------------|-------------|
-| `RG_NAME` | `nevridge-taskflow-qa-rg` | Resource group name (can be overridden by input) |
-| `ACR_NAME` | `nevridgetaskflowqaacr` | Container registry name (can be overridden by input) |
-| `ACI_NAME` | `nevridge-taskflow-qa-aci` | Container instance name (fixed) |
-| `DNS_NAME_LABEL` | `taskflow-qa` | DNS label for predictable endpoint (fixed) |
-| `LOCATION` | `eastus` | Azure region (from input or default) |
-| `IMAGE_TAG` | `latest` | Image tag (from input or default) |
-
-**Note**: Input parameters allow overriding computed names for testing purposes, but standard deployments should use the computed names for consistency.
-
-## Deployment Process
-
-### Deploy Action Steps
-
-1. **Checkout Code**: Clones the repository
-2. **Azure Login**: Authenticates with Azure using service principal
-3. **Verify Subscription**: Sets the correct Azure subscription
-4. **Register Provider**: Ensures Microsoft.ContainerInstance provider is registered
-5. **Compute Names**: Sets environment variables for resources
-6. **Ensure Resource Group**: Creates resource group if it doesn't exist
-7. **Ensure ACR**: Creates Azure Container Registry if it doesn't exist
-8. **Build and Push Image**: Builds Docker image using ACR build
-9. **Delete Existing ACI**: Removes previous QA container if present
-10. **Create ACI**: Deploys new container with fixed DNS name `taskflow-qa`
-11. **Wait for Ready**: Polls for FQDN and confirms container is running
-12. **Smoke Test**: Validates deployment via `/health` endpoint
-
-### Teardown Action Steps
-
-1. **Checkout Code**: Clones the repository
-2. **Azure Login**: Authenticates with Azure
-3. **Delete Resource Group**: Removes the entire resource group (including ACI and ACR if not shared)
+**Archive Note:** The original QA deployment used Azure's workflow_dispatch trigger to create and destroy containers automatically. This approach has been replaced with a GitOps model where all deployments are version-controlled in the `nevridge/taskflow-deploy` repository.
 
 ## Using the QA Endpoint
 

--- a/docs/QA_DEPLOYMENT.md
+++ b/docs/QA_DEPLOYMENT.md
@@ -21,20 +21,25 @@ For current deployment procedures, refer to:
 
 ---
 
-**Archive Note:** The original QA deployment used Azure's workflow_dispatch trigger to create and destroy containers automatically. This approach has been replaced with a GitOps model where all deployments are version-controlled in the `nevridge/taskflow-deploy` repository.
+## Legacy QA Instructions (ARCHIVED)
 
-## Using the QA Endpoint
+> **⚠️ Do not follow these instructions.** The QA endpoint is no longer active. The sections below are retained for historical reference only.
 
-### For Manual Testing
+The following sections describe how the legacy Azure Container Instances QA deployment worked. These instructions should not be used for any new deployments or testing.
 
-The QA endpoint is always available at the same URL:
+For current deployment and testing procedures, use the production Docker Host deployment via Portainer GitOps:
+- See [DEPLOYMENT.md](DEPLOYMENT.md) for deployment procedures
+- See [DOCKER_CONFIGURATION.md](DOCKER_CONFIGURATION.md) for Docker Compose setup
+
+---
+
+### Legacy: Using the QA Endpoint
+
+*This section is archived. The QA endpoint is no longer active.*
+
+The Azure QA endpoint was available at:
 ```
 http://taskflow-qa.{region}.azurecontainer.io:8080
-```
-
-Example for East US region:
-```
-http://taskflow-qa.eastus.azurecontainer.io:8080
 ```
 
 ### For Postman Testing

--- a/docs/VOLUMES.md
+++ b/docs/VOLUMES.md
@@ -572,20 +572,27 @@ The new configuration will create Docker named volumes automatically.
 
 ### For Docker Host Deployment (Production)
 
-Docker Host (Portainer GitOps) uses the same named volumes configuration as local development:
+Docker Host (Portainer GitOps) uses Docker Compose with named volumes, but with different volume names than development to prevent data conflicts:
 
-1. **Configuration is automatic** - `docker-compose.prod.yml` defines volumes
-2. **Data persists across restarts** - Volumes outlive container lifecycle  
-3. **No path overrides needed** - Consistent `/app/data` and `/app/logs` paths work everywhere
+**Volume Names:**
+- **Development** (docker-compose.yml): `taskflow-data`, `taskflow-logs`
+- **Production** (docker-compose.prod.yml): `taskflow-data-prod`, `taskflow-logs-prod`
 
-Your data in volumes will automatically persist when using the standard compose configuration.
+**Configuration:**
+1. **Configuration is automatic** - `docker-compose.prod.yml` creates and manages volumes
+2. **Separate volumes** - Production volumes are isolated from development (prevents accidental overwrites)
+3. **Consistent paths** - Container paths are `/app/data` and `/app/logs` in both environments
+4. **Data persists** - Volumes outlive container lifecycle
+
+Your data in volumes will automatically persist when using the standard compose configuration. When migrating data between environments, ensure you're using the correct volume names for each environment.
 
 ## Summary
 
 - **Volume Type**: Docker named volumes (default) or bind mounts (alternative)
 - **Default container paths**: `/app/logs` for logs, `/app/data` for database
+- **Development volumes**: `taskflow-data` and `taskflow-logs` (docker-compose.yml)
+- **Production volumes**: `taskflow-data-prod` and `taskflow-logs-prod` (docker-compose.prod.yml)
 - **Environment variables**: `LOG_PATH` and `ConnectionStrings__DefaultConnection` for customization
-- **Docker Compose**: Uses named volumes `taskflow-data` and `taskflow-logs` for persistence
 - **Persistence**: Data persists across container removal/recreation until volumes are explicitly deleted
 - **Management**: Use `docker volume` commands to manage, backup, and restore volumes
 - **Best practice**: Use Docker named volumes for most scenarios, bind mounts for advanced debugging

--- a/docs/VOLUMES.md
+++ b/docs/VOLUMES.md
@@ -217,24 +217,19 @@ This configuration:
      taskflow-api:latest
    ```
 
-### Azure App Service
+### Docker Compose (Recommended for production Docker deployments)
 
-When deploying to Azure App Service, the `/home` directory is persistent across restarts. You have two options:
+When deploying with Docker Compose to an on-premises Docker Host (via Portainer GitOps), use named volumes for persistence:
 
-**Option 1: Use Azure persistent storage (recommended)**
-
-Override the database path to use `/home`:
 ```bash
-az webapp config appsettings set \
-  --resource-group TaskFlowRG \
-  --name taskflowapi \
-  --settings \
-    ConnectionStrings__DefaultConnection="Data Source=/home/data/tasks.db"
+docker compose -f docker-compose.prod.yml up -d
 ```
 
-**Option 2: Use default paths with volume mounts**
-
-The default `/app/data` and `/app/logs` paths will work, but data will only persist as long as the container is running. For production, use Option 1 or configure Azure File Storage mounts.
+This configuration automatically:
+- Creates and manages named volumes (`taskflow-data`, `taskflow-logs`)
+- Persists data across container restarts
+- Provides consistent paths across environments
+- Supports backup and restore operations
 
 ## Managing Docker Volumes
 
@@ -445,16 +440,12 @@ docker compose down -v
 docker compose up --build
 ```
 
-### Different behavior in Azure vs. local
+### Different behavior in different environments
 
-**Symptom**: Application works locally but fails in Azure App Service.
-
-**Solutions:**
-- Azure App Service persists `/home` by default, not `/app`
-- Override paths using environment variables in Azure:
-  - `LOG_PATH=/home/logs/log.txt`
-  - `ConnectionStrings__DefaultConnection="Data Source=/home/data/tasks.db"`
-- Or mount Azure File Storage to `/app/data` and `/app/logs`
+**Local Development vs. Docker Host:**
+- Local: Docker Desktop manages volumes automatically
+- Docker Host: Portainer GitOps handles volume lifecycle
+- Both: Same Docker named volumes configuration, consistent behavior across environments
 
 ## Migration Guide
 
@@ -579,17 +570,15 @@ If you're upgrading from a previous version that used `/home/logs` and `/home/ta
 
 The new configuration will create Docker named volumes automatically.
 
-### For Azure Deployment
+### For Docker Host Deployment (Production)
 
-Azure App Service uses `/home` for persistent storage. To maintain compatibility:
+Docker Host (Portainer GitOps) uses the same named volumes configuration as local development:
 
-1. **Set environment variables in Azure Portal:**
-   - `LOG_PATH=/home/logs/log.txt`
-   - `ConnectionStrings__DefaultConnection="Data Source=/home/data/tasks.db"`
+1. **Configuration is automatic** - `docker-compose.prod.yml` defines volumes
+2. **Data persists across restarts** - Volumes outlive container lifecycle  
+3. **No path overrides needed** - Consistent `/app/data` and `/app/logs` paths work everywhere
 
-2. **Or update your deployment workflow** to include these settings.
-
-Your existing data and logs in `/home` will continue to work without migration.
+Your data in volumes will automatically persist when using the standard compose configuration.
 
 ## Summary
 
@@ -599,10 +588,8 @@ Your existing data and logs in `/home` will continue to work without migration.
 - **Docker Compose**: Uses named volumes `taskflow-data` and `taskflow-logs` for persistence
 - **Persistence**: Data persists across container removal/recreation until volumes are explicitly deleted
 - **Management**: Use `docker volume` commands to manage, backup, and restore volumes
-- **Azure App Service**: Override paths to use `/home` for persistent storage
 - **Best practice**: Use Docker named volumes for most scenarios, bind mounts for advanced debugging
 - **Migration**: Follow the migration guide above if upgrading from bind mounts
-
 ---
 
 [← Back to README](../README.md) | [Docker Configuration](DOCKER_CONFIGURATION.md) | [Volume Testing →](VOLUME_TESTING.md)


### PR DESCRIPTION
- Replace Azure Container Instances/App Service references with Portainer GitOps deployment
- Update production URLs to taskflow.skalaforge.com / taskflow-api.skalaforge.com
- Archive QA_DEPLOYMENT.md and AZURE_OIDC_AUTHENTICATION.md with deprecation notices
- Remove Azure-specific configuration from VOLUMES.md, LOGGING.md, HEALTH_CHECK_TESTING.md
- Update health check testing to include Docker Host (Portainer) guidance
- Remove Azure API Design references from API_VERSIONING.md
- Update documentation references to reflect on-premises Docker deployment pattern
- All archived files retain historical content but clearly marked as deprecated