### PR TITLE
Redesign tasks page: priority grouping, search, icon actions, clickable status

### DIFF
--- a/TaskFlow.Web/src/components/TaskListRow.test.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.test.tsx
@@ -15,17 +15,19 @@ const baseTask: TaskItemResponseDto = {
   isComplete: false,
 }
 
+type TaskHandler = (task: TaskItemResponseDto) => void
+
 function renderRow(
   task: TaskItemResponseDto = baseTask,
   overrides: {
-    onEdit?: ReturnType<typeof vi.fn>
-    onDelete?: ReturnType<typeof vi.fn>
-    onStatusCycle?: ReturnType<typeof vi.fn>
+    onEdit?: TaskHandler
+    onDelete?: TaskHandler
+    onStatusCycle?: TaskHandler
   } = {},
 ) {
-  const onEdit = overrides.onEdit ?? vi.fn()
-  const onDelete = overrides.onDelete ?? vi.fn()
-  const onStatusCycle = overrides.onStatusCycle ?? vi.fn()
+  const onEdit = overrides.onEdit ?? vi.fn<TaskHandler>()
+  const onDelete = overrides.onDelete ?? vi.fn<TaskHandler>()
+  const onStatusCycle = overrides.onStatusCycle ?? vi.fn<TaskHandler>()
   return render(
     <MemoryRouter>
       <table>
@@ -33,7 +35,7 @@ function renderRow(
           <TaskListRow
             task={task}
             onEdit={onEdit}
-            onHistory={vi.fn()}
+            onHistory={vi.fn<TaskHandler>()}
             onDelete={onDelete}
             onStatusCycle={onStatusCycle}
           />

--- a/TaskFlow.Web/src/components/TaskListRow.test.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.test.tsx
@@ -17,20 +17,25 @@ const baseTask: TaskItemResponseDto = {
 
 function renderRow(
   task: TaskItemResponseDto = baseTask,
-  isOnTodayJournal = false,
-  onEdit = vi.fn(),
-  onDelete = vi.fn(),
+  overrides: {
+    onEdit?: ReturnType<typeof vi.fn>
+    onDelete?: ReturnType<typeof vi.fn>
+    onStatusCycle?: ReturnType<typeof vi.fn>
+  } = {},
 ) {
+  const onEdit = overrides.onEdit ?? vi.fn()
+  const onDelete = overrides.onDelete ?? vi.fn()
+  const onStatusCycle = overrides.onStatusCycle ?? vi.fn()
   return render(
     <MemoryRouter>
       <table>
         <tbody>
           <TaskListRow
             task={task}
-            isOnTodayJournal={isOnTodayJournal}
             onEdit={onEdit}
             onHistory={vi.fn()}
             onDelete={onDelete}
+            onStatusCycle={onStatusCycle}
           />
         </tbody>
       </table>
@@ -52,26 +57,23 @@ describe('TaskListRow', () => {
 
   it('calls onEdit when edit button is clicked', async () => {
     const onEdit = vi.fn()
-    renderRow(baseTask, false, onEdit)
+    renderRow(baseTask, { onEdit })
     await userEvent.click(screen.getByRole('button', { name: /edit/i }))
     expect(onEdit).toHaveBeenCalledWith(baseTask)
   })
 
   it('calls onDelete when delete button is clicked', async () => {
     const onDelete = vi.fn()
-    renderRow(baseTask, false, vi.fn(), onDelete)
+    renderRow(baseTask, { onDelete })
     await userEvent.click(screen.getByRole('button', { name: /delete/i }))
     expect(onDelete).toHaveBeenCalledWith(baseTask)
   })
 
-  it('shows journal indicator when task is on today journal', () => {
-    renderRow(baseTask, true)
-    expect(screen.getByLabelText("On today's journal")).toBeInTheDocument()
-  })
-
-  it('does not show journal indicator when task is not on today journal', () => {
-    renderRow(baseTask, false)
-    expect(screen.queryByLabelText("On today's journal")).not.toBeInTheDocument()
+  it('calls onStatusCycle when status badge is clicked', async () => {
+    const onStatusCycle = vi.fn()
+    renderRow(baseTask, { onStatusCycle })
+    await userEvent.click(screen.getByRole('button', { name: /todo/i }))
+    expect(onStatusCycle).toHaveBeenCalledWith(baseTask)
   })
 
   it('shows formatted due date when present', () => {
@@ -91,7 +93,6 @@ describe('TaskListRow', () => {
     it('marks past-due incomplete tasks as overdue', () => {
       const task = { ...baseTask, dueDate: pastDate, status: 'todo' }
       renderRow(task)
-      // The overdue icon (!) should be present
       expect(screen.getByText('!', { selector: '.t-overdue-icon' })).toBeInTheDocument()
     })
 

--- a/TaskFlow.Web/src/components/TaskListRow.tsx
+++ b/TaskFlow.Web/src/components/TaskListRow.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { formatDate } from '@/lib/utils'
-import { formatShort, todayISO } from '@/lib/journal-utils'
+import { todayISO } from '@/lib/journal-utils'
 import type { TaskItemResponseDto } from '@/api/client/types.gen'
 
 type TaskRowModel = TaskItemResponseDto & {
@@ -18,21 +18,38 @@ interface Props {
   hasChildren?: boolean
   isExpanded?: boolean
   childProgress?: string | null
-  isOnTodayJournal: boolean
   onToggleChildren?: (task: TaskRowModel) => void
   onAddChild?: (task: TaskRowModel) => void
   isAddingChild?: boolean
   onEdit: (task: TaskRowModel) => void
   onHistory: (task: TaskRowModel) => void
   onDelete: (task: TaskRowModel) => void
+  onStatusCycle: (task: TaskRowModel) => void
 }
 
 function isOverdue(dueDate: string | null | undefined, status: string | undefined): boolean {
   if (!dueDate) return false
   if ((status ?? '').toLowerCase() === 'completed') return false
-  // Compare ISO date strings (YYYY-MM-DD) to avoid timezone offset issues with UTC-stored dates
   return dueDate.slice(0, 10) < todayISO()
 }
+
+function isDueToday(dueDate: string | null | undefined): boolean {
+  if (!dueDate) return false
+  return dueDate.slice(0, 10) === todayISO()
+}
+
+const PlusIcon = () => (
+  <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
+)
+const ClockIcon = () => (
+  <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /><polyline points="12 7 12 12 15 15" /></svg>
+)
+const PencilIcon = () => (
+  <svg viewBox="0 0 24 24"><path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /></svg>
+)
+const XIcon = () => (
+  <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+)
 
 export function TaskListRow({
   task,
@@ -40,25 +57,33 @@ export function TaskListRow({
   hasChildren = false,
   isExpanded = false,
   childProgress,
-  isOnTodayJournal,
   onToggleChildren,
   onAddChild,
   isAddingChild = false,
   onEdit,
   onHistory,
   onDelete,
+  onStatusCycle,
 }: Props) {
   const status = (task.status ?? 'draft').toLowerCase()
   const priority = (task.priority ?? 'low').toLowerCase()
   const overdue = isOverdue(task.dueDate, task.status)
-  const assignedDate = task.currentJournalDate ?? null
-  const isScheduledFuture = !!assignedDate && assignedDate > todayISO()
   const moveCount = task.moveCount ?? 0
   const daysTagged = task.daysTagged ?? 0
-  const childTaskCount = task.childTaskCount ?? task.childCount ?? 0
+  const isCompleted = status === 'completed'
+  const highDeferral = moveCount >= 3
+  const showDeferral = moveCount > 0 || daysTagged > 1
+  const boldTitle = isDueToday(task.dueDate) && priority === 'high'
+
+  const rowClasses = [
+    't-list-row',
+    isCompleted && 't-row--completed',
+    !isCompleted && overdue && 't-row--overdue',
+    !isCompleted && !overdue && highDeferral && 't-row--high-deferral',
+  ].filter(Boolean).join(' ')
 
   return (
-    <tr className="t-list-row">
+    <tr className={rowClasses}>
       <td className="t-list-cell t-list-cell--title">
         <div className={`t-title-wrap t-depth-${depth}`}>
           {hasChildren ? (
@@ -73,13 +98,33 @@ export function TaskListRow({
           ) : (
             <span className="t-tree-spacer" aria-hidden="true" />
           )}
-          <Link to={`/tasks/${task.id}`} className="t-task-link">
-            {task.title}
-          </Link>
+          <div>
+            <Link to={`/tasks/${task.id}`} className={`t-task-link${boldTitle ? ' t-title-bold' : ''}`}>
+              {task.title}
+            </Link>
+            {childProgress && <div className="t-deferral-line">{childProgress}</div>}
+            {showDeferral && (
+              <div className="t-deferral-line">
+                {highDeferral && <span className="t-deferral-badge">{'↻'} {moveCount}</span>}
+                {highDeferral && daysTagged > 1 && ' · '}
+                {!highDeferral && moveCount > 0 && <>Moved {moveCount}{daysTagged > 1 ? ' · ' : ''}</>}
+                {daysTagged > 1 && <>Tagged {daysTagged} days</>}
+              </div>
+            )}
+          </div>
         </div>
       </td>
       <td className="t-list-cell">
-        <span className={`t-badge t-badge-${status}`}>{status}</span>
+        <span
+          className={`t-badge t-badge-${status} t-badge-clickable`}
+          onClick={() => onStatusCycle(task)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onStatusCycle(task) } }}
+          aria-label={`Status: ${status}. Click to change.`}
+        >
+          {status}
+        </span>
       </td>
       <td className="t-list-cell">
         <span className={`t-badge t-badge-${priority}`}>{priority}</span>
@@ -94,38 +139,23 @@ export function TaskListRow({
             {formatDate(task.dueDate)}
           </span>
         ) : (
-          <span className="t-list-empty">—</span>
-        )}
-      </td>
-      <td className="t-list-cell t-list-cell--journal">
-        {assignedDate ? (
-          <div>
-            <div>{formatShort(assignedDate)}</div>
-            {isScheduledFuture && <span className="t-badge t-badge-scheduled">scheduled for {formatShort(assignedDate)}</span>}
-          </div>
-        ) : (
-          <span className="t-list-empty">—</span>
-        )}
-      </td>
-      <td className="t-list-cell t-list-cell--movement">
-        <div className="t-movement-cell">Tagged {daysTagged}d · Moved {moveCount}</div>
-        <div className="t-movement-sub">
-          {childProgress ?? `${task.parentTaskItemId ? `Parent #${task.parentTaskItemId}` : 'No parent'} · ${childTaskCount} child${childTaskCount === 1 ? '' : 'ren'}`}
-        </div>
-      </td>
-      <td className="t-list-cell t-list-cell--journal">
-        {isOnTodayJournal && (
-          <span className="t-journal-dot" title="On today's journal" role="img" aria-label="On today's journal">
-            📔
-          </span>
+          <span className="t-list-empty">{'—'}</span>
         )}
       </td>
       <td className="t-list-cell t-list-cell--actions">
         <div className="t-card-actions">
-          <button className={`t-btn${isAddingChild ? ' is-active' : ''}`} aria-label="Add subtask" onClick={() => onAddChild?.(task)}>Subtask</button>
-          <button className="t-btn" aria-label="History" onClick={() => onHistory(task)}>History</button>
-          <button className="t-btn" aria-label="Edit" onClick={() => onEdit(task)}>Edit</button>
-          <button className="t-btn-danger" aria-label="Delete" onClick={() => onDelete(task)}>Delete</button>
+          <button className={`t-btn-icon${isAddingChild ? ' is-active' : ''}`} aria-label="Add subtask" title="Add subtask" onClick={() => onAddChild?.(task)}>
+            <PlusIcon />
+          </button>
+          <button className="t-btn-icon" aria-label="Task history" title="Task history" onClick={() => onHistory(task)}>
+            <ClockIcon />
+          </button>
+          <button className="t-btn-icon" aria-label="Edit" title="Edit" onClick={() => onEdit(task)}>
+            <PencilIcon />
+          </button>
+          <button className="t-btn-icon t-btn-icon--danger" aria-label="Delete" title="Delete" onClick={() => onDelete(task)}>
+            <XIcon />
+          </button>
         </div>
       </td>
     </tr>

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -8,30 +8,33 @@ import {
   type TaskItemViewModel,
   type UpdateTaskPayload,
 } from '@/hooks/useTasks'
-import { useJournalEntries } from '@/hooks/useJournal'
 import { usePrefs } from '@/context/usePrefs'
 import { TaskListRow } from '@/components/TaskListRow'
 import { TaskHistoryPanel } from '@/components/TaskHistoryPanel'
 import { TaskForm, type TaskFormPayload } from '@/components/TaskForm'
 import type { TaskSortKey } from '@/lib/prefs'
-import type { JournalEntryResponseDto } from '@/api/journal'
 import { todayISO } from '@/lib/journal-utils'
 import '@/tasks.css'
 
 type StatusFilter = 'all' | 'draft' | 'todo' | 'completed'
-type PriorityFilter = 'all' | 'low' | 'medium' | 'high'
 type ViewFilter = 'all' | 'activeToday' | 'scheduledFuture' | 'completedHistory'
-
-const priorityOrder = { high: 0, medium: 1, low: 2 }
-
-interface ColHeader {
-  key: TaskSortKey
-  label: string
-}
 
 type TaskListModel = TaskItemViewModel
 
-const COLUMNS: ColHeader[] = [
+type PriorityGroup = {
+  key: string
+  label: string
+  cssModifier: string
+  tasks: Array<{ task: TaskListModel; depth: number }>
+}
+
+const STATUS_CYCLE: Record<string, string> = {
+  draft: 'todo',
+  todo: 'completed',
+  completed: 'draft',
+}
+
+const COLUMNS: Array<{ key: TaskSortKey; label: string }> = [
   { key: 'title', label: 'Title' },
   { key: 'status', label: 'Status' },
   { key: 'priority', label: 'Priority' },
@@ -40,7 +43,6 @@ const COLUMNS: ColHeader[] = [
 
 export function TasksPage() {
   const { data, isLoading, error } = useTasksQuery()
-  const { data: journalData } = useJournalEntries()
   const createMutation = useCreateTaskMutation()
   const updateMutation = useUpdateTaskMutation()
   const deleteMutation = useDeleteTaskMutation()
@@ -53,31 +55,34 @@ export function TasksPage() {
   } = usePrefs()
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
-  const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>('all')
   const [viewFilter, setViewFilter] = useState<ViewFilter>('all')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [editingTask, setEditingTask] = useState<TaskListModel | null>(null)
   const [historyTask, setHistoryTask] = useState<TaskListModel | null>(null)
   const [showCreate, setShowCreate] = useState(false)
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [expandedParentIds, setExpandedParentIds] = useState<Set<number>>(new Set())
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
   const [addingChildForTaskId, setAddingChildForTaskId] = useState<number | null>(null)
   const [childDraftTitle, setChildDraftTitle] = useState('')
   const historyCloseRef = useRef<HTMLButtonElement | null>(null)
   const knownParentIdsRef = useRef<Set<number>>(new Set())
 
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), 200)
+    return () => clearTimeout(timer)
+  }, [searchQuery])
+
   useEffect(() => {
     if (!historyTask) return
-
     const previousOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
     historyCloseRef.current?.focus()
-
     const handleEsc = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setHistoryTask(null)
-      }
+      if (event.key === 'Escape') setHistoryTask(null)
     }
-
     window.addEventListener('keydown', handleEsc)
     return () => {
       window.removeEventListener('keydown', handleEsc)
@@ -90,10 +95,6 @@ export function TasksPage() {
     [data],
   )
 
-  const todayEntry = ((journalData?.data as JournalEntryResponseDto[] | undefined) ?? [])
-    .find(e => e.date === todayISO())
-  const todayTaskIds = new Set<number>(todayEntry?.todoTaskItemIds ?? [])
-
   function handleSortClick(key: TaskSortKey) {
     if (key === taskSortKey) {
       setTaskSortDir(taskSortDir === 'asc' ? 'desc' : 'asc')
@@ -103,23 +104,41 @@ export function TasksPage() {
     }
   }
 
-  const filtered = tasks
-    .filter(t => matchesViewFilter(t, viewFilter))
-    .filter(t => statusFilter === 'all' || t.status?.toLowerCase() === statusFilter)
-    .filter(t => priorityFilter === 'all' || t.priority?.toLowerCase() === priorityFilter)
-    .sort((a, b) => {
-      let cmp = 0
-      if (taskSortKey === 'title') cmp = a.title.localeCompare(b.title)
-      else if (taskSortKey === 'dueDate') cmp = (a.dueDate ?? '').localeCompare(b.dueDate ?? '')
-      else if (taskSortKey === 'status') cmp = (a.status ?? '').localeCompare(b.status ?? '')
-      else if (taskSortKey === 'priority') {
-        const pa = priorityOrder[(a.priority ?? '').toLowerCase() as keyof typeof priorityOrder] ?? 2
-        const pb = priorityOrder[(b.priority ?? '').toLowerCase() as keyof typeof priorityOrder] ?? 2
-        cmp = pa - pb
-      }
-      return taskSortDir === 'asc' ? cmp : -cmp
-    })
+  function sortIcon(key: TaskSortKey): string {
+    if (key !== taskSortKey) return ''
+    return taskSortDir === 'asc' ? ' ↑' : ' ↓'
+  }
 
+  // Apply filters: view filter, status filter, search
+  const filtered = useMemo(() => {
+    return tasks
+      .filter(t => matchesViewFilter(t, viewFilter))
+      .filter(t => statusFilter === 'all' || (t.status ?? '').toLowerCase() === statusFilter)
+      .filter(t => !debouncedSearch || t.title.toLowerCase().includes(debouncedSearch.toLowerCase()))
+  }, [tasks, viewFilter, statusFilter, debouncedSearch])
+
+  // Sort comparator for within-group sorting
+  function compareWithinGroup(a: TaskListModel, b: TaskListModel): number {
+    // Default: due date ascending (overdue first, then soonest, no-date last)
+    const aDue = a.dueDate ?? ''
+    const bDue = b.dueDate ?? ''
+    if (!aDue && bDue) return 1
+    if (aDue && !bDue) return -1
+    let cmp = aDue.localeCompare(bDue)
+
+    // If user has set a custom sort, use it as secondary
+    if (taskSortKey === 'title') cmp = a.title.localeCompare(b.title)
+    else if (taskSortKey === 'status') cmp = (a.status ?? '').localeCompare(b.status ?? '')
+    else if (taskSortKey === 'dueDate') {
+      if (!aDue && bDue) return 1
+      if (aDue && !bDue) return -1
+      cmp = aDue.localeCompare(bDue)
+    }
+
+    return taskSortDir === 'asc' ? cmp : -cmp
+  }
+
+  // Build child lookup maps
   const filteredById = useMemo(
     () => new Map(filtered.map(task => [Number(task.id), task])),
     [filtered],
@@ -130,14 +149,9 @@ export function TasksPage() {
     tasks.forEach(task => {
       const parentId = task.parentTaskItemId ? Number(task.parentTaskItemId) : null
       if (!parentId) return
-
       const prev = stats.get(parentId) ?? { done: 0, total: 0 }
-      const status = (task.status ?? '').toLowerCase()
-      const isDone = status === 'completed' || !!task.isComplete
-      stats.set(parentId, {
-        total: prev.total + 1,
-        done: prev.done + (isDone ? 1 : 0),
-      })
+      const isDone = (task.status ?? '').toLowerCase() === 'completed' || !!task.isComplete
+      stats.set(parentId, { total: prev.total + 1, done: prev.done + (isDone ? 1 : 0) })
     })
     return stats
   }, [tasks])
@@ -165,65 +179,88 @@ export function TasksPage() {
       const next = new Set(prev)
       const known = knownParentIdsRef.current
       parentIds.forEach(id => {
-        if (!known.has(id)) {
-          next.add(id)
-          known.add(id)
-          changed = true
-        }
+        if (!known.has(id)) { next.add(id); known.add(id); changed = true }
       })
-
       for (const knownId of Array.from(known)) {
-        if (!parentIds.includes(knownId)) {
-          known.delete(knownId)
-        }
+        if (!parentIds.includes(knownId)) known.delete(knownId)
       }
-
       return changed ? next : prev
     })
   }, [parentIds])
 
-  const hierarchicalRows = useMemo(() => {
-    const rows: Array<{ task: TaskListModel; depth: number }> = []
-    const rootTasks = filtered.filter(task => {
-      const parentId = task.parentTaskItemId ? Number(task.parentTaskItemId) : null
-      return !parentId || !filteredById.has(parentId)
-    })
+  // Build priority groups with hierarchical rows
+  const priorityGroups: PriorityGroup[] = useMemo(() => {
+    const groupDefs = [
+      { key: 'high', label: 'High Priority', cssModifier: 'high' },
+      { key: 'medium', label: 'Medium Priority', cssModifier: 'medium' },
+      { key: 'low', label: 'Low Priority', cssModifier: 'low' },
+      { key: 'draft', label: 'Draft', cssModifier: 'draft' },
+    ]
 
-    rootTasks.forEach(parent => {
-      rows.push({ task: parent, depth: 0 })
-      const parentId = Number(parent.id)
-      const children = childrenByParentId.get(parentId) ?? []
-      if (children.length > 0 && expandedParentIds.has(parentId)) {
-        children.forEach(child => rows.push({ task: child, depth: 1 }))
-      }
-    })
+    return groupDefs.map(def => {
+      const groupTasks = filtered.filter(t => {
+        const status = (t.status ?? '').toLowerCase()
+        if (def.key === 'draft') return status === 'draft'
+        return status !== 'draft' && (t.priority ?? 'low').toLowerCase() === def.key
+      })
 
-    return rows
-  }, [childrenByParentId, expandedParentIds, filtered, filteredById])
+      const sorted = [...groupTasks].sort(compareWithinGroup)
+      const rootTasks = sorted.filter(task => {
+        const parentId = task.parentTaskItemId ? Number(task.parentTaskItemId) : null
+        return !parentId || !filteredById.has(parentId)
+      })
 
-  function handleCreate(data: TaskFormPayload) {
+      const rows: Array<{ task: TaskListModel; depth: number }> = []
+      rootTasks.forEach(parent => {
+        rows.push({ task: parent, depth: 0 })
+        const parentId = Number(parent.id)
+        const children = childrenByParentId.get(parentId) ?? []
+        if (children.length > 0 && expandedParentIds.has(parentId)) {
+          children.forEach(child => rows.push({ task: child, depth: 1 }))
+        }
+      })
+
+      return { ...def, tasks: rows }
+    }).filter(g => g.tasks.length > 0)
+  }, [filtered, filteredById, childrenByParentId, expandedParentIds, taskSortKey, taskSortDir])
+
+  // Handlers
+  function handleCreate(formData: TaskFormPayload) {
     setMutationError(null)
-    createMutation.mutate(data as CreateTaskPayload, {
+    createMutation.mutate(formData as CreateTaskPayload, {
       onSuccess: () => setShowCreate(false),
       onError: err => setMutationError(getTaskMutationErrorMessage(err)),
     })
   }
 
-  function handleUpdate(data: TaskFormPayload) {
+  function handleUpdate(formData: TaskFormPayload) {
     if (!editingTask?.id) return
     setMutationError(null)
     updateMutation.mutate(
+      { id: Number(editingTask.id), data: { ...(formData as UpdateTaskPayload), autoCompleteParentWhenChildrenDone } as UpdateTaskPayload },
+      { onSuccess: () => setEditingTask(null), onError: err => setMutationError(getTaskMutationErrorMessage(err)) }
+    )
+  }
+
+  function handleStatusCycle(task: TaskListModel) {
+    const currentStatus = (task.status ?? 'draft').toLowerCase()
+    const nextStatus = STATUS_CYCLE[currentStatus] ?? 'draft'
+    setMutationError(null)
+    updateMutation.mutate(
       {
-        id: Number(editingTask.id),
+        id: Number(task.id),
         data: {
-          ...(data as UpdateTaskPayload),
+          title: task.title,
+          description: task.description,
+          status: nextStatus as 'draft' | 'todo' | 'completed',
+          isComplete: nextStatus === 'completed',
+          priority: task.priority as 'low' | 'medium' | 'high' | undefined,
+          dueDate: task.dueDate,
+          parentTaskItemId: task.parentTaskItemId,
           autoCompleteParentWhenChildrenDone,
         } as UpdateTaskPayload,
       },
-      {
-        onSuccess: () => setEditingTask(null),
-        onError: err => setMutationError(getTaskMutationErrorMessage(err)),
-      }
+      { onError: err => setMutationError(getTaskMutationErrorMessage(err)) }
     )
   }
 
@@ -250,41 +287,39 @@ export function TasksPage() {
     })
   }
 
+  function toggleGroup(groupKey: string) {
+    setCollapsedGroups(prev => {
+      const next = new Set(prev)
+      if (next.has(groupKey)) next.delete(groupKey)
+      else next.add(groupKey)
+      return next
+    })
+  }
+
   function beginAddChild(task: TaskListModel) {
     setMutationError(null)
     setAddingChildForTaskId(Number(task.id))
     setChildDraftTitle('')
-    setExpandedParentIds(prev => {
-      const next = new Set(prev)
-      next.add(Number(task.id))
-      return next
-    })
+    setExpandedParentIds(prev => { const next = new Set(prev); next.add(Number(task.id)); return next })
   }
 
   function submitAddChild() {
     const parentId = addingChildForTaskId
     const title = childDraftTitle.trim()
     if (!parentId || !title) return
-
     setMutationError(null)
     createMutation.mutate(
       { title, status: 'todo', parentTaskItemId: parentId } as CreateTaskPayload,
       {
-        onSuccess: () => {
-          setAddingChildForTaskId(null)
-          setChildDraftTitle('')
-        },
+        onSuccess: () => { setAddingChildForTaskId(null); setChildDraftTitle('') },
         onError: err => setMutationError(getTaskMutationErrorMessage(err)),
       },
     )
   }
 
-  function sortIcon(key: TaskSortKey): string {
-    if (key !== taskSortKey) return ''
-    return taskSortDir === 'asc' ? ' ↑' : ' ↓'
-  }
+  const totalFiltered = priorityGroups.reduce((sum, g) => sum + g.tasks.length, 0)
 
-  if (isLoading) return <div className="tasks-page"><div className="t-shell"><p className="t-loading">Loading tasks…</p></div></div>
+  if (isLoading) return <div className="tasks-page"><div className="t-shell"><p className="t-loading">Loading tasks...</p></div></div>
   if (error) return <div className="tasks-page"><div className="t-shell"><p className="t-error">Failed to load tasks.</p></div></div>
 
   return (
@@ -325,43 +360,37 @@ export function TasksPage() {
         )}
 
         <div className="t-filter-row">
+          <div className="t-search-wrap">
+            <input
+              type="text"
+              className="t-search-input"
+              placeholder="Search tasks..."
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+            />
+            {searchQuery && (
+              <button className="t-search-clear" onClick={() => setSearchQuery('')} aria-label="Clear search">{'×'}</button>
+            )}
+          </div>
           <div className="t-chip-group" aria-label="Task view filters">
             <button type="button" className={`t-chip${viewFilter === 'all' ? ' is-active' : ''}`} onClick={() => setViewFilter('all')}>All</button>
             <button type="button" className={`t-chip${viewFilter === 'activeToday' ? ' is-active' : ''}`} onClick={() => setViewFilter('activeToday')}>Active today</button>
             <button type="button" className={`t-chip${viewFilter === 'scheduledFuture' ? ' is-active' : ''}`} onClick={() => setViewFilter('scheduledFuture')}>Scheduled future</button>
             <button type="button" className={`t-chip${viewFilter === 'completedHistory' ? ' is-active' : ''}`} onClick={() => setViewFilter('completedHistory')}>Completed history</button>
           </div>
-
-          <label htmlFor="status-filter" className="t-filter-label">Status</label>
-          <select
-            id="status-filter"
-            className="t-select"
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value as StatusFilter)}
-          >
+          <span className="t-filter-label">Status</span>
+          <select id="status-filter" className="t-select" value={statusFilter} onChange={e => setStatusFilter(e.target.value as StatusFilter)}>
             <option value="all">All</option>
             <option value="draft">Draft</option>
             <option value="todo">Todo</option>
             <option value="completed">Completed</option>
           </select>
-
-          <label htmlFor="priority-filter" className="t-filter-label">Priority</label>
-          <select
-            id="priority-filter"
-            className="t-select"
-            value={priorityFilter}
-            onChange={e => setPriorityFilter(e.target.value as PriorityFilter)}
-          >
-            <option value="all">All</option>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-          </select>
-
-          <span className="t-filter-count">{filtered.length} task{filtered.length !== 1 ? 's' : ''}</span>
+          <span className="t-filter-count">{totalFiltered} task{totalFiltered !== 1 ? 's' : ''}</span>
         </div>
 
-        {filtered.length === 0 ? (
+        {mutationError && !showCreate && !editingTask && <p className="t-inline-error">{mutationError}</p>}
+
+        {totalFiltered === 0 ? (
           <p className="t-empty">No tasks match your filters.</p>
         ) : (
           <div className="t-list-wrap">
@@ -374,74 +403,75 @@ export function TasksPage() {
                       className={`t-list-th${col.key === taskSortKey ? ' t-col-sort--active' : ''}`}
                       aria-sort={col.key === taskSortKey ? (taskSortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
                     >
-                      <button
-                        type="button"
-                        className="t-col-sort-btn"
-                        onClick={() => handleSortClick(col.key)}
-                      >
+                      <button type="button" className="t-col-sort-btn" onClick={() => handleSortClick(col.key)}>
                         {col.label}{sortIcon(col.key)}
                       </button>
                     </th>
                   ))}
-                  <th className="t-list-th">Assigned Day</th>
-                  <th className="t-list-th t-list-th--movement">Movement</th>
-                  <th className="t-list-th t-list-th--journal" title="On today's journal">Journal</th>
                   <th className="t-list-th t-list-th--actions" aria-label="Actions"></th>
                 </tr>
               </thead>
               <tbody>
-                {hierarchicalRows.map(({ task, depth }) => {
-                  const taskId = Number(task.id)
-                  const children = childrenByParentId.get(taskId) ?? []
-                  const hasChildren = children.length > 0
-                  const childStats = childStatsByParentId.get(taskId)
-                  const childProgress = childStats ? `${childStats.done}/${childStats.total} subtasks complete` : null
-
+                {priorityGroups.map(group => {
+                  const isCollapsed = collapsedGroups.has(group.key)
                   return (
-                    <Fragment key={`row-group-${taskId}`}>
-                      <TaskListRow
-                        key={`task-${taskId}`}
-                        task={task}
-                        depth={depth}
-                        hasChildren={hasChildren}
-                        isExpanded={hasChildren ? expandedParentIds.has(taskId) : undefined}
-                        childProgress={childProgress}
-                        isOnTodayJournal={todayTaskIds.has(taskId)}
-                        onToggleChildren={hasChildren ? toggleChildren : undefined}
-                        onAddChild={beginAddChild}
-                        isAddingChild={addingChildForTaskId === taskId}
-                        onEdit={setEditingTask}
-                        onHistory={setHistoryTask}
-                        onDelete={handleDelete}
-                      />
+                    <Fragment key={group.key}>
+                      <tr className={`t-group-header t-group-header--${group.cssModifier}`}>
+                        <td colSpan={5}>
+                          <button type="button" className="t-group-toggle" onClick={() => toggleGroup(group.key)}>
+                            <span className={`t-group-chevron${isCollapsed ? ' t-group-chevron--collapsed' : ''}`}>{'▾'}</span>
+                            {group.label}
+                            <span className="t-group-count">{'·'} {group.tasks.length} task{group.tasks.length !== 1 ? 's' : ''}</span>
+                          </button>
+                        </td>
+                      </tr>
+                      {!isCollapsed && group.tasks.map(({ task, depth }) => {
+                        const taskId = Number(task.id)
+                        const children = childrenByParentId.get(taskId) ?? []
+                        const hasChildren = children.length > 0
+                        const childStats = childStatsByParentId.get(taskId)
+                        const childProgress = childStats ? `${childStats.done}/${childStats.total} subtasks complete` : null
 
-                      {addingChildForTaskId === taskId && (
-                        <tr key={`add-child-${taskId}`} className="t-list-row t-list-row--child-editor">
-                          <td className="t-list-cell" colSpan={8}>
-                            <div className="t-subtask-editor">
-                              <span className="t-subtask-label">New subtask</span>
-                              <input
-                                className="t-input"
-                                placeholder="Enter subtask title"
-                                value={childDraftTitle}
-                                onChange={e => setChildDraftTitle(e.target.value)}
-                                onKeyDown={e => {
-                                  if (e.key === 'Enter') {
-                                    e.preventDefault()
-                                    submitAddChild()
-                                  }
-                                  if (e.key === 'Escape') {
-                                    setAddingChildForTaskId(null)
-                                    setChildDraftTitle('')
-                                  }
-                                }}
-                              />
-                              <button className="t-btn" onClick={() => { setAddingChildForTaskId(null); setChildDraftTitle('') }}>Cancel</button>
-                              <button className="t-btn-primary" onClick={submitAddChild} disabled={!childDraftTitle.trim()}>Add</button>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
+                        return (
+                          <Fragment key={`row-group-${taskId}`}>
+                            <TaskListRow
+                              task={task}
+                              depth={depth}
+                              hasChildren={hasChildren}
+                              isExpanded={hasChildren ? expandedParentIds.has(taskId) : undefined}
+                              childProgress={childProgress}
+                              onToggleChildren={hasChildren ? toggleChildren : undefined}
+                              onAddChild={beginAddChild}
+                              isAddingChild={addingChildForTaskId === taskId}
+                              onEdit={setEditingTask}
+                              onHistory={setHistoryTask}
+                              onDelete={handleDelete}
+                              onStatusCycle={handleStatusCycle}
+                            />
+                            {addingChildForTaskId === taskId && (
+                              <tr key={`add-child-${taskId}`} className="t-list-row t-list-row--child-editor">
+                                <td className="t-list-cell" colSpan={5}>
+                                  <div className="t-subtask-editor">
+                                    <span className="t-subtask-label">New subtask</span>
+                                    <input
+                                      className="t-input"
+                                      placeholder="Enter subtask title"
+                                      value={childDraftTitle}
+                                      onChange={e => setChildDraftTitle(e.target.value)}
+                                      onKeyDown={e => {
+                                        if (e.key === 'Enter') { e.preventDefault(); submitAddChild() }
+                                        if (e.key === 'Escape') { setAddingChildForTaskId(null); setChildDraftTitle('') }
+                                      }}
+                                    />
+                                    <button className="t-btn" onClick={() => { setAddingChildForTaskId(null); setChildDraftTitle('') }}>Cancel</button>
+                                    <button className="t-btn-primary" onClick={submitAddChild} disabled={!childDraftTitle.trim()}>Add</button>
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </Fragment>
+                        )
+                      })}
                     </Fragment>
                   )
                 })}
@@ -456,38 +486,14 @@ export function TasksPage() {
 
 function getTaskMutationErrorMessage(error: unknown): string {
   const code = getErrorCode(error)
-  if (code === 'TASK_REOPEN_PAST_DAY_NOT_ALLOWED') {
-    return 'Completed tasks assigned to past days cannot be reopened.'
-  }
-
-  if (code === 'TASK_PARENT_COMPLETE_BLOCKED_BY_CHILDREN' || code === 'TASK_PARENT_INCOMPLETE_CHILDREN') {
-    return 'Parent tasks cannot be completed while child tasks are still open.'
-  }
-
-  if (code === 'TASK_PARENT_SELF_NOT_ALLOWED') {
-    return 'A task cannot be set as its own parent.'
-  }
-
-  if (code === 'TASK_PARENT_CYCLE_NOT_ALLOWED') {
-    return 'This parent assignment would create a cycle.'
-  }
-
-  if (code === 'TASK_PARENT_DEPTH_NOT_ALLOWED') {
-    return 'Only one subtask level is supported.'
-  }
-
-  if (code === 'TASK_PARENT_DELETE_BLOCKED_BY_CHILDREN') {
-    return 'This task has subtasks. Remove or reassign subtasks before deleting.'
-  }
-
-  if (code === 'TASK_PARENT_NOT_FOUND') {
-    return 'The selected parent task was not found.'
-  }
-
-  if (code === 'TASK_CREATION_PAST_DAY_NOT_ALLOWED') {
-    return 'You cannot create new tasks on a past journal day.'
-  }
-
+  if (code === 'TASK_REOPEN_PAST_DAY_NOT_ALLOWED') return 'Completed tasks assigned to past days cannot be reopened.'
+  if (code === 'TASK_PARENT_COMPLETE_BLOCKED_BY_CHILDREN' || code === 'TASK_PARENT_INCOMPLETE_CHILDREN') return 'Parent tasks cannot be completed while child tasks are still open.'
+  if (code === 'TASK_PARENT_SELF_NOT_ALLOWED') return 'A task cannot be set as its own parent.'
+  if (code === 'TASK_PARENT_CYCLE_NOT_ALLOWED') return 'This parent assignment would create a cycle.'
+  if (code === 'TASK_PARENT_DEPTH_NOT_ALLOWED') return 'Only one subtask level is supported.'
+  if (code === 'TASK_PARENT_DELETE_BLOCKED_BY_CHILDREN') return 'This task has subtasks. Remove or reassign subtasks before deleting.'
+  if (code === 'TASK_PARENT_NOT_FOUND') return 'The selected parent task was not found.'
+  if (code === 'TASK_CREATION_PAST_DAY_NOT_ALLOWED') return 'You cannot create new tasks on a past journal day.'
   return 'Unable to save task changes. Please try again.'
 }
 
@@ -501,15 +507,10 @@ function matchesViewFilter(task: TaskListModel, viewFilter: ViewFilter): boolean
   const assignedDate = task.currentJournalDate ?? null
   const status = (task.status ?? '').toLowerCase()
   const isCompleted = status === 'completed' || !!task.isComplete
-
   switch (viewFilter) {
-    case 'activeToday':
-      return assignedDate === todayISO() && !isCompleted
-    case 'scheduledFuture':
-      return assignedDate != null && assignedDate > todayISO()
-    case 'completedHistory':
-      return isCompleted && assignedDate != null && assignedDate < todayISO()
-    default:
-      return true
+    case 'activeToday': return assignedDate === todayISO() && !isCompleted
+    case 'scheduledFuture': return assignedDate != null && assignedDate > todayISO()
+    case 'completedHistory': return isCompleted && assignedDate != null && assignedDate < todayISO()
+    default: return true
   }
 }

--- a/TaskFlow.Web/src/pages/TasksPage.tsx
+++ b/TaskFlow.Web/src/pages/TasksPage.tsx
@@ -117,21 +117,25 @@ export function TasksPage() {
       .filter(t => !debouncedSearch || t.title.toLowerCase().includes(debouncedSearch.toLowerCase()))
   }, [tasks, viewFilter, statusFilter, debouncedSearch])
 
-  // Sort comparator for within-group sorting
+  const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 }
+
   function compareWithinGroup(a: TaskListModel, b: TaskListModel): number {
-    // Default: due date ascending (overdue first, then soonest, no-date last)
+    let cmp = 0
     const aDue = a.dueDate ?? ''
     const bDue = b.dueDate ?? ''
-    if (!aDue && bDue) return 1
-    if (aDue && !bDue) return -1
-    let cmp = aDue.localeCompare(bDue)
 
-    // If user has set a custom sort, use it as secondary
-    if (taskSortKey === 'title') cmp = a.title.localeCompare(b.title)
-    else if (taskSortKey === 'status') cmp = (a.status ?? '').localeCompare(b.status ?? '')
-    else if (taskSortKey === 'dueDate') {
-      if (!aDue && bDue) return 1
-      if (aDue && !bDue) return -1
+    if (taskSortKey === 'title') {
+      cmp = a.title.localeCompare(b.title)
+    } else if (taskSortKey === 'status') {
+      cmp = (a.status ?? '').localeCompare(b.status ?? '')
+    } else if (taskSortKey === 'priority') {
+      const pa = PRIORITY_ORDER[(a.priority ?? '').toLowerCase()] ?? 2
+      const pb = PRIORITY_ORDER[(b.priority ?? '').toLowerCase()] ?? 2
+      cmp = pa - pb
+    } else {
+      // Default: due date — no-date items sort last in asc, first in desc
+      if (!aDue && bDue) return taskSortDir === 'asc' ? 1 : -1
+      if (aDue && !bDue) return taskSortDir === 'asc' ? -1 : 1
       cmp = aDue.localeCompare(bDue)
     }
 
@@ -378,7 +382,7 @@ export function TasksPage() {
             <button type="button" className={`t-chip${viewFilter === 'scheduledFuture' ? ' is-active' : ''}`} onClick={() => setViewFilter('scheduledFuture')}>Scheduled future</button>
             <button type="button" className={`t-chip${viewFilter === 'completedHistory' ? ' is-active' : ''}`} onClick={() => setViewFilter('completedHistory')}>Completed history</button>
           </div>
-          <span className="t-filter-label">Status</span>
+          <label htmlFor="status-filter" className="t-filter-label">Status</label>
           <select id="status-filter" className="t-select" value={statusFilter} onChange={e => setStatusFilter(e.target.value as StatusFilter)}>
             <option value="all">All</option>
             <option value="draft">Draft</option>

--- a/TaskFlow.Web/src/tasks.css
+++ b/TaskFlow.Web/src/tasks.css
@@ -717,3 +717,184 @@ html.is-dark .t-input option { background: var(--paper); }
     align-items: stretch;
   }
 }
+
+/* --- Group headers --- */
+
+.t-group-header td {
+  padding: 10px 14px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+}
+
+.t-group-header--high td { color: var(--danger-ink); border-left: 3px solid var(--danger-ink); }
+.t-group-header--medium td { color: var(--warn-ink); border-left: 3px solid var(--warn-ink); }
+.t-group-header--low td { color: var(--muted); border-left: 3px solid var(--muted-2); }
+.t-group-header--draft td { color: var(--muted-2); border-left: 3px solid var(--line); }
+
+.t-group-count {
+  font-weight: 400;
+  font-size: 11px;
+  margin-left: 6px;
+  opacity: .7;
+}
+
+.t-group-chevron {
+  margin-right: 6px;
+  font-size: 10px;
+  display: inline-block;
+  transition: transform .15s;
+}
+
+.t-group-chevron--collapsed {
+  transform: rotate(-90deg);
+}
+
+.t-group-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+
+/* --- Urgency cues --- */
+
+.t-row--overdue {
+  border-left: 3px solid var(--danger-ink);
+}
+
+.t-row--high-deferral {
+  border-left: 3px solid var(--warn-ink);
+}
+
+.t-row--completed {
+  opacity: .55;
+}
+
+.t-row--completed .t-task-link {
+  text-decoration: line-through;
+}
+
+.t-title-bold {
+  font-weight: 700;
+}
+
+.t-deferral-line {
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.t-deferral-badge {
+  color: var(--warn-ink);
+  font-weight: 600;
+  font-size: 11px;
+}
+
+/* --- Icon buttons --- */
+
+.t-btn-icon {
+  width: 30px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 14px;
+  transition: background .12s, color .12s, border-color .12s;
+  padding: 0;
+}
+
+.t-btn-icon:hover {
+  background: var(--hover-soft);
+  color: var(--ink);
+  border-color: var(--line-2);
+}
+
+.t-btn-icon--danger:hover {
+  background: var(--danger-bg);
+  color: var(--danger-ink);
+  border-color: color-mix(in oklab, var(--danger-ink) 30%, transparent);
+}
+
+.t-btn-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* --- Clickable status badge --- */
+
+.t-badge-clickable {
+  cursor: pointer;
+  transition: transform .1s;
+  user-select: none;
+}
+
+.t-badge-clickable:hover {
+  transform: scale(1.08);
+}
+
+.t-badge-clickable:active {
+  transform: scale(.95);
+}
+
+/* --- Search input --- */
+
+.t-search-input {
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius-sm);
+  background: var(--paper-2);
+  color: var(--ink);
+  padding: 6px 12px;
+  font-size: 13px;
+  outline: none;
+  width: 220px;
+  transition: border-color .12s;
+}
+
+.t-search-input:focus {
+  border-color: var(--accent);
+}
+
+.t-search-input::placeholder {
+  color: var(--muted-2);
+}
+
+.t-search-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.t-search-clear {
+  position: absolute;
+  right: 6px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px;
+  line-height: 1;
+}
+
+.t-search-clear:hover {
+  color: var(--ink);
+}


### PR DESCRIPTION
## Summary

- **Reduced table columns from 8 to 5** by removing Assigned Day, Movement (standalone), and Journal columns. Movement/deferral info relocated as a conditional secondary line under the task title.
- **Added priority-based grouping** with collapsible section headers (High → Medium → Low → Draft). Draft-status tasks always appear in the Draft group regardless of priority. Each header shows a colored left border accent and task count.
- **Added clickable status badges** that cycle through draft → todo → completed → draft on click, enabling quick task completion without opening the edit form.
- **Replaced 4 text action buttons with compact SVG icon buttons** (+, clock, pencil, ×) to reduce visual noise.
- **Added text search** with debounced filtering (200ms) across all priority groups, with a clear button.
- **Added visual urgency cues**: red left border + red date text for overdue tasks, amber left border for high-deferral tasks (moveCount >= 3), bold title for high-priority tasks due today, and reduced opacity + strikethrough for completed tasks.

## Test plan

- [x] Load `/tasks` with mixed task states (overdue, different priorities, completed, drafts) — verify grouping and urgency borders
- [x] Click a status badge through all 3 states — verify API call fires and UI updates
- [x] Type in search box — verify instant filtering across groups with clear button
- [x] Click column headers — verify sort applies within each priority group
- [x] Expand/collapse parent tasks — verify children remain indented within correct group
- [x] Switch view filters (All / Active today / Scheduled future / Completed history) — verify grouping applies to filtered results
- [x] Run `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)