### PR TITLE
feat: keyboard shortcut system for journal page

### DIFF
--- a/TaskFlow.Web/src/components/journal/DailyLogSection.tsx
+++ b/TaskFlow.Web/src/components/journal/DailyLogSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, forwardRef, useImperativeHandle } from 'react'
 import type { JournalLogEntryResponseDto } from '@/api/journal'
 import { useAddLogEntryMutation, useDeleteLogEntryMutation } from '@/hooks/useJournal'
 import { formatTime } from '@/lib/journal-utils'
@@ -8,12 +8,20 @@ interface Props {
   logEntries: JournalLogEntryResponseDto[]
 }
 
-export function DailyLogSection({ entryId, logEntries }: Props) {
+export interface DailyLogSectionHandle {
+  focusDraftInput: () => void
+}
+
+export const DailyLogSection = forwardRef<DailyLogSectionHandle, Props>(function DailyLogSection({ entryId, logEntries }, ref) {
   const addLog = useAddLogEntryMutation(entryId)
   const deleteLog = useDeleteLogEntryMutation(entryId)
 
   const [draft, setDraft] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    focusDraftInput: () => inputRef.current?.focus(),
+  }))
 
   function addEntry(e: React.FormEvent) {
     e.preventDefault()
@@ -64,8 +72,11 @@ export function DailyLogSection({ entryId, logEntries }: Props) {
           value={draft}
           onChange={e => setDraft(e.target.value)}
           disabled={addLog.isPending}
+          onKeyDown={e => {
+            if (e.key === 'Escape') { setDraft(''); inputRef.current?.blur() }
+          }}
         />
       </form>
     </section>
   )
-}
+})

--- a/TaskFlow.Web/src/components/journal/KeyboardShortcutsModal.tsx
+++ b/TaskFlow.Web/src/components/journal/KeyboardShortcutsModal.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from 'react'
+
+interface Props {
+  onClose: () => void
+}
+
+const SHORTCUTS = [
+  {
+    group: 'Actions',
+    items: [
+      { keys: ['t'], description: 'New todo' },
+      { keys: ['l'], description: 'New log entry' },
+      { keys: ['n'], description: 'Focus notes' },
+      { keys: ['?'], description: 'Show / hide this help' },
+    ],
+  },
+  {
+    group: 'Navigation',
+    items: [
+      { keys: ['['], description: 'Previous day' },
+      { keys: [']'], description: 'Next day' },
+      { keys: ['g', 'h'], description: 'Go to today (home)' },
+      { keys: ['g', 't'], description: 'Go to tasks page' },
+    ],
+  },
+  {
+    group: 'Inputs',
+    items: [
+      { keys: ['Esc'], description: 'Cancel / deselect focused field' },
+    ],
+  },
+]
+
+export function KeyboardShortcutsModal({ onClose }: Props) {
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    closeRef.current?.focus()
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' || e.key === '?') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [onClose])
+
+  return (
+    <>
+      <div className="j-modal-backdrop" onClick={onClose} aria-hidden="true" />
+      <div
+        className="j-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="kb-modal-title"
+      >
+        <div className="j-modal-header">
+          <h3 id="kb-modal-title" className="j-modal-title">Keyboard shortcuts</h3>
+          <button ref={closeRef} className="j-modal-close" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        <div className="kb-groups">
+          {SHORTCUTS.map(group => (
+            <div key={group.group} className="kb-group">
+              <h4 className="kb-group-label">{group.group}</h4>
+              <table className="kb-table">
+                <tbody>
+                  {group.items.map(item => (
+                    <tr key={item.description} className="kb-row">
+                      <td className="kb-keys">
+                        {item.keys.map((k, i) => (
+                          <span key={k}>
+                            <kbd className="kb-kbd">{k}</kbd>
+                            {i < item.keys.length - 1 && (
+                              <span className="kb-then">then</span>
+                            )}
+                          </span>
+                        ))}
+                      </td>
+                      <td className="kb-desc">{item.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/TaskFlow.Web/src/components/journal/KeyboardShortcutsModal.tsx
+++ b/TaskFlow.Web/src/components/journal/KeyboardShortcutsModal.tsx
@@ -35,6 +35,7 @@ export function KeyboardShortcutsModal({ onClose }: Props) {
   const closeRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null
     closeRef.current?.focus()
 
     const previousOverflow = document.body.style.overflow
@@ -45,12 +46,17 @@ export function KeyboardShortcutsModal({ onClose }: Props) {
         e.preventDefault()
         onClose()
       }
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        closeRef.current?.focus()
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
       document.body.style.overflow = previousOverflow
+      previouslyFocused?.focus()
     }
   }, [onClose])
 

--- a/TaskFlow.Web/src/components/journal/NotesSection.tsx
+++ b/TaskFlow.Web/src/components/journal/NotesSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react'
 import { useUpdateNotesMutation } from '@/hooks/useJournal'
 
 interface Props {
@@ -7,11 +7,20 @@ interface Props {
   initialValue: string | null | undefined
 }
 
-export function NotesSection({ entryId, entryTitle, initialValue }: Props) {
+export interface NotesSectionHandle {
+  focusNotes: () => void
+}
+
+export const NotesSection = forwardRef<NotesSectionHandle, Props>(function NotesSection({ entryId, entryTitle, initialValue }, ref) {
   const [value, setValue] = useState(initialValue ?? '')
   const [savedAt, setSavedAt] = useState<number | null>(null)
   const updateNotes = useUpdateNotesMutation(entryId, entryTitle)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    focusNotes: () => textareaRef.current?.focus(),
+  }))
 
   useEffect(() => {
     return () => {
@@ -40,11 +49,15 @@ export function NotesSection({ entryId, entryTitle, initialValue }: Props) {
         </div>
       </div>
       <textarea
+        ref={textareaRef}
         className="notes-area"
         placeholder="Free-form notes for the day — observations, decisions, follow-ups, anything."
         value={value}
         onChange={handleChange}
+        onKeyDown={e => {
+          if (e.key === 'Escape') textareaRef.current?.blur()
+        }}
       />
     </section>
   )
-}
+})

--- a/TaskFlow.Web/src/components/journal/TodosSection.tsx
+++ b/TaskFlow.Web/src/components/journal/TodosSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useMemo, useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import type { TaskItemResponseDto } from '@/api/journal'
 import { TaskHistoryPanel } from '@/components/TaskHistoryPanel'
 import {
@@ -19,7 +19,11 @@ interface Props {
   sort: SortMode
 }
 
-export function TodosSection({ entryId, isoDate, sort }: Props) {
+export interface TodosSectionHandle {
+  focusDraftInput: () => void
+}
+
+export const TodosSection = forwardRef<TodosSectionHandle, Props>(function TodosSection({ entryId, isoDate, sort }, ref) {
   const { data: todosData, isLoading } = useJournalTodos(entryId)
   const todos = useMemo<TaskItemResponseDto[]>(
     () => (todosData?.data as TaskItemResponseDto[] | undefined) ?? [],
@@ -37,6 +41,11 @@ export function TodosSection({ entryId, isoDate, sort }: Props) {
   const [actionError, setActionError] = useState<string | null>(null)
   const [historyTask, setHistoryTask] = useState<TaskItemResponseDto | null>(null)
   const historyCloseRef = useRef<HTMLButtonElement | null>(null)
+  const draftInputRef = useRef<HTMLInputElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    focusDraftInput: () => draftInputRef.current?.focus(),
+  }))
 
   useEffect(() => {
     if (!historyTask) return
@@ -213,11 +222,15 @@ export function TodosSection({ entryId, isoDate, sort }: Props) {
       <form className="add-row" onSubmit={addTodo}>
         <span className="add-plus">+</span>
         <input
+          ref={draftInputRef}
           className="add-input"
           placeholder={isPastDay ? 'Adding tasks is disabled for past dates' : 'Add a TODO and press Enter'}
           value={draft}
           onChange={e => setDraft(e.target.value)}
           disabled={createTodo.isPending || isPastDay}
+          onKeyDown={e => {
+            if (e.key === 'Escape') { setDraft(''); draftInputRef.current?.blur() }
+          }}
         />
       </form>
 
@@ -238,7 +251,7 @@ export function TodosSection({ entryId, isoDate, sort }: Props) {
       )}
     </section>
   )
-}
+})
 
 function getTaskActionErrorMessage(error: unknown): string {
   const code = getErrorCode(error)

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useJournalKeyboardShortcuts } from './useJournalKeyboardShortcuts'
+import type { JournalShortcutHandlers } from './useJournalKeyboardShortcuts'
+
+function makeHandlers(): JournalShortcutHandlers {
+  return {
+    onNewTodo: vi.fn(),
+    onNewLog: vi.fn(),
+    onFocusNotes: vi.fn(),
+    onPrevDay: vi.fn(),
+    onNextDay: vi.fn(),
+    onGoHome: vi.fn(),
+    onGoTasks: vi.fn(),
+    onShowHelp: vi.fn(),
+  }
+}
+
+function fireKey(key: string, options: KeyboardEventInit = {}) {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...options }))
+}
+
+describe('useJournalKeyboardShortcuts', () => {
+  let handlers: JournalShortcutHandlers
+
+  beforeEach(() => {
+    handlers = makeHandlers()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('fires onNewTodo when t is pressed with no input focused', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('t')
+    expect(handlers.onNewTodo).toHaveBeenCalledOnce()
+  })
+
+  it('fires onNewLog when l is pressed', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('l')
+    expect(handlers.onNewLog).toHaveBeenCalledOnce()
+  })
+
+  it('fires onFocusNotes when n is pressed', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('n')
+    expect(handlers.onFocusNotes).toHaveBeenCalledOnce()
+  })
+
+  it('fires onPrevDay when [ is pressed', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('[')
+    expect(handlers.onPrevDay).toHaveBeenCalledOnce()
+  })
+
+  it('fires onNextDay when ] is pressed', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey(']')
+    expect(handlers.onNextDay).toHaveBeenCalledOnce()
+  })
+
+  it('fires onShowHelp when ? is pressed', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
+  })
+
+  it('does not fire shortcuts when an input is focused', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('t')
+    fireKey('l')
+    fireKey('n')
+    fireKey('[')
+    fireKey(']')
+    fireKey('?')
+
+    expect(handlers.onNewTodo).not.toHaveBeenCalled()
+    expect(handlers.onNewLog).not.toHaveBeenCalled()
+    expect(handlers.onFocusNotes).not.toHaveBeenCalled()
+    expect(handlers.onPrevDay).not.toHaveBeenCalled()
+    expect(handlers.onNextDay).not.toHaveBeenCalled()
+    expect(handlers.onShowHelp).not.toHaveBeenCalled()
+  })
+
+  it('does not fire shortcuts when a textarea is focused', () => {
+    const ta = document.createElement('textarea')
+    document.body.appendChild(ta)
+    ta.focus()
+
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('t')
+    expect(handlers.onNewTodo).not.toHaveBeenCalled()
+  })
+
+  it('does not fire shortcuts when modifier keys are held', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('t', { ctrlKey: true })
+    fireKey('t', { altKey: true })
+    fireKey('t', { metaKey: true })
+    expect(handlers.onNewTodo).not.toHaveBeenCalled()
+  })
+
+  it('g then h within 1.5s triggers onGoHome', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('g')
+    vi.advanceTimersByTime(500)
+    fireKey('h')
+    expect(handlers.onGoHome).toHaveBeenCalledOnce()
+    expect(handlers.onGoTasks).not.toHaveBeenCalled()
+  })
+
+  it('g then t within 1.5s triggers onGoTasks', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('g')
+    vi.advanceTimersByTime(500)
+    fireKey('t')
+    expect(handlers.onGoTasks).toHaveBeenCalledOnce()
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+  })
+
+  it('chord times out after 1.5s and subsequent h does not trigger onGoHome', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('g')
+    vi.advanceTimersByTime(1500)
+    fireKey('h')
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+  })
+
+  it('g then unknown key silently cancels the chord', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('g')
+    fireKey('x')
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+    expect(handlers.onGoTasks).not.toHaveBeenCalled()
+    // Subsequent shortcuts should still work
+    fireKey('t')
+    expect(handlers.onNewTodo).toHaveBeenCalledOnce()
+  })
+
+  it('chord fires even while an input is focused (second key)', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('g')
+    input.focus()
+    fireKey('h')
+    expect(handlers.onGoHome).toHaveBeenCalledOnce()
+  })
+
+  it('removes the keydown listener on unmount', () => {
+    const { unmount } = renderHook(() => useJournalKeyboardShortcuts(handlers))
+    unmount()
+    fireKey('t')
+    expect(handlers.onNewTodo).not.toHaveBeenCalled()
+  })
+})

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
@@ -1,0 +1,106 @@
+import { useEffect, useRef } from 'react'
+
+export interface JournalShortcutHandlers {
+  onNewTodo: () => void
+  onNewLog: () => void
+  onFocusNotes: () => void
+  onPrevDay: () => void
+  onNextDay: () => void
+  onGoHome: () => void
+  onGoTasks: () => void
+  onShowHelp: () => void
+}
+
+function isInputFocused(): boolean {
+  const el = document.activeElement
+  if (!el) return false
+  const tag = el.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el as HTMLElement).isContentEditable
+}
+
+/**
+ * Global keyboard shortcut handler for the journal page.
+ *
+ * Single-key shortcuts fire only when no text input is focused (Gmail convention).
+ * Two-key chords (g → h, g → t) use a 1.5s window after pressing g.
+ */
+export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
+  // Use a ref so the effect closure always sees the latest handlers
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
+
+  // Track pending chord: null = no chord, 'g' = waiting for second key
+  const pendingChordRef = useRef<string | null>(null)
+  const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    function clearChord() {
+      pendingChordRef.current = null
+      if (chordTimerRef.current !== null) {
+        clearTimeout(chordTimerRef.current)
+        chordTimerRef.current = null
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      // Never fire shortcuts from modifier combos (Ctrl/Alt/Meta)
+      if (e.ctrlKey || e.altKey || e.metaKey) return
+
+      // If a chord is pending, handle the second key regardless of input focus
+      if (pendingChordRef.current === 'g') {
+        clearChord()
+        if (e.key === 'h') {
+          e.preventDefault()
+          handlersRef.current.onGoHome()
+        } else if (e.key === 't') {
+          e.preventDefault()
+          handlersRef.current.onGoTasks()
+        }
+        // Any other key silently cancels the chord
+        return
+      }
+
+      // Single-key shortcuts only fire when no text field is active
+      if (isInputFocused()) return
+
+      switch (e.key) {
+        case '?':
+          e.preventDefault()
+          handlersRef.current.onShowHelp()
+          break
+        case 't':
+          e.preventDefault()
+          handlersRef.current.onNewTodo()
+          break
+        case 'l':
+          e.preventDefault()
+          handlersRef.current.onNewLog()
+          break
+        case 'n':
+          e.preventDefault()
+          handlersRef.current.onFocusNotes()
+          break
+        case '[':
+          e.preventDefault()
+          handlersRef.current.onPrevDay()
+          break
+        case ']':
+          e.preventDefault()
+          handlersRef.current.onNextDay()
+          break
+        case 'g':
+          // Start chord; wait up to 1.5s for the second key
+          e.preventDefault()
+          pendingChordRef.current = 'g'
+          chordTimerRef.current = setTimeout(clearChord, 1500)
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      if (chordTimerRef.current !== null) clearTimeout(chordTimerRef.current)
+    }
+  }, []) // stable — handlers accessed via ref
+}

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 
 export interface JournalShortcutHandlers {
   onNewTodo: () => void
@@ -27,7 +27,9 @@ function isInputFocused(): boolean {
 export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
   // Use a ref so the effect closure always sees the latest handlers
   const handlersRef = useRef(handlers)
-  handlersRef.current = handlers
+  useLayoutEffect(() => {
+    handlersRef.current = handlers
+  })
 
   // Track pending chord: null = no chord, 'g' = waiting for second key
   const pendingChordRef = useRef<string | null>(null)

--- a/TaskFlow.Web/src/journal.css
+++ b/TaskFlow.Web/src/journal.css
@@ -436,6 +436,65 @@
 }
 .journal-page .j-modal-close:hover { background: var(--hover-soft); }
 
+/* ─── Keyboard shortcuts modal ─────────────────────────────────────────────── */
+
+.kb-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.kb-group-label {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--muted);
+}
+
+.kb-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.kb-row td {
+  padding: 5px 0;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 13.5px;
+}
+.kb-row:last-child td { border-bottom: 0; }
+
+.kb-keys {
+  width: 140px;
+  white-space: nowrap;
+}
+
+.kb-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  background: var(--paper-2);
+  font: 12px/1 ui-monospace, 'Cascadia Code', 'Fira Mono', monospace;
+  color: var(--ink);
+}
+
+.kb-then {
+  display: inline-block;
+  margin: 0 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.kb-desc {
+  color: var(--ink-2);
+}
+
 /* ─── Daily Log ────────────────────────────────────────────────────────────── */
 
 .log-list {

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -1,17 +1,23 @@
-import { useMemo } from 'react'
-import { useParams, useOutletContext } from 'react-router-dom'
+import { useMemo, useRef, useState } from 'react'
+import { useParams, useOutletContext, useNavigate } from 'react-router-dom'
 import { useEnsureJournalEntry } from '@/hooks/useJournal'
-import { urlDateToISO, todayISO, isValidISODate } from '@/lib/journal-utils'
+import { urlDateToISO, todayISO, isValidISODate, addDays, isoToUrlDate } from '@/lib/journal-utils'
 import { DateNav } from '@/components/journal/DateNav'
 import { JournalHeader } from '@/components/journal/JournalHeader'
 import { TodosSection } from '@/components/journal/TodosSection'
+import type { TodosSectionHandle } from '@/components/journal/TodosSection'
 import { DailyLogSection } from '@/components/journal/DailyLogSection'
+import type { DailyLogSectionHandle } from '@/components/journal/DailyLogSection'
 import { NotesSection } from '@/components/journal/NotesSection'
+import type { NotesSectionHandle } from '@/components/journal/NotesSection'
+import { KeyboardShortcutsModal } from '@/components/journal/KeyboardShortcutsModal'
+import { useJournalKeyboardShortcuts } from '@/hooks/useJournalKeyboardShortcuts'
 import type { AppContext } from '@/components/Layout'
 import '@/journal.css'
 
 export function JournalPage() {
   const { date: urlDate } = useParams<{ date: string }>()
+  const navigate = useNavigate()
 
   const isoDate = useMemo(
     () => (urlDate ? urlDateToISO(urlDate) : todayISO()),
@@ -24,6 +30,23 @@ export function JournalPage() {
   const { entry, isLoading, error } = useEnsureJournalEntry(effectiveDate)
 
   const { isDark, headerStyle, todoSort, projectStart } = useOutletContext<AppContext>()
+
+  const [showShortcuts, setShowShortcuts] = useState(false)
+
+  const todosSectionRef = useRef<TodosSectionHandle>(null)
+  const logSectionRef = useRef<DailyLogSectionHandle>(null)
+  const notesSectionRef = useRef<NotesSectionHandle>(null)
+
+  useJournalKeyboardShortcuts({
+    onNewTodo: () => todosSectionRef.current?.focusDraftInput(),
+    onNewLog: () => logSectionRef.current?.focusDraftInput(),
+    onFocusNotes: () => notesSectionRef.current?.focusNotes(),
+    onPrevDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, -1))}`),
+    onNextDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, 1))}`),
+    onGoHome: () => navigate(`/journal/${isoToUrlDate(todayISO())}`),
+    onGoTasks: () => navigate('/tasks'),
+    onShowHelp: () => setShowShortcuts(prev => !prev),
+  })
 
   return (
     <div className={'journal-page' + (isDark ? ' is-dark' : '')}>
@@ -45,17 +68,20 @@ export function JournalPage() {
             <>
               <section className="j-grid">
                 <TodosSection
+                  ref={todosSectionRef}
                   entryId={entry.id}
                   isoDate={effectiveDate}
                   sort={todoSort}
                 />
                 <DailyLogSection
+                  ref={logSectionRef}
                   entryId={entry.id}
                   logEntries={entry.logEntries}
                 />
               </section>
 
               <NotesSection
+                ref={notesSectionRef}
                 key={entry.id}
                 entryId={entry.id}
                 entryTitle={entry.title}
@@ -65,6 +91,10 @@ export function JournalPage() {
           ) : null}
         </article>
       </div>
+
+      {showShortcuts && (
+        <KeyboardShortcutsModal onClose={() => setShowShortcuts(false)} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds a comprehensive keyboard shortcut system to the daily journal page, following the Gmail/Linear convention of single-key shortcuts that only fire when no text input is focused.

## Shortcuts

| Key | Action |
|-----|--------|
| `t` | Focus new todo input |
| `l` | Focus new log entry input |
| `n` | Focus notes textarea |
| `[` | Previous day |
| `]` | Next day |
| `g` then `h` | Go to today's journal (home) |
| `g` then `t` | Go to tasks page |
| `?` | Show / hide keyboard shortcuts help |
| `Esc` (in any input) | Blur and cancel draft (notes: blur only) |

## Implementation

- `useJournalKeyboardShortcuts` hook — document-level keydown listener with active-element guard; tracks `pendingChord` ref for two-key g->h / g->t sequences with a 1.5s window
- `KeyboardShortcutsModal` — help overlay using existing j-modal CSS classes, shortcuts grouped by Actions / Navigation / Inputs with styled kbd chips
- `TodosSection`, `DailyLogSection`, `NotesSection` — each wrapped in `forwardRef` + `useImperativeHandle` to expose focus methods to the parent; per-input Esc handlers added
- `JournalPage` — holds section refs, wires shortcut callbacks, renders the help modal
- `journal.css` — kb-* styles for the shortcut table with kbd chip styling

## Testing

- `tsc --noEmit`: no errors
- `npm run build`: clean build
- `dotnet test`: 193/193 passing (backend unchanged)
