### PR TITLE
feat: replace single-note textarea with per-entry notes list

### DIFF
--- a/TaskFlow.Api.Tests/Controllers/V1/JournalNotesControllerV1Tests.cs
+++ b/TaskFlow.Api.Tests/Controllers/V1/JournalNotesControllerV1Tests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using TaskFlow.Api.Controllers.V1;
+using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repositories;
+
+namespace TaskFlow.Api.Tests.Controllers.V1;
+
+public class JournalNotesControllerV1Tests
+{
+    private readonly Mock<IJournalEntryRepository> _entryRepo = new();
+    private readonly Mock<IJournalNoteRepository> _noteRepo = new();
+    private readonly Mock<IValidator<JournalNote>> _validator = new();
+    private readonly JournalNotesController _controller;
+
+    private static JournalEntry MakeEntry(int id = 1) =>
+        new() { Id = id, Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+
+    private static JournalNote MakeNote(int id = 1, int entryId = 1) =>
+        new() { Id = id, JournalEntryId = entryId, Content = "A note", CreatedAt = DateTime.UtcNow };
+
+    public JournalNotesControllerV1Tests()
+    {
+        _controller = new JournalNotesController(_entryRepo.Object, _noteRepo.Object, _validator.Object);
+    }
+
+    // ── GetAll ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAll_ShouldReturn200_WithNotes_WhenEntryExists()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetAllByEntryIdAsync(1))
+            .ReturnsAsync([MakeNote(1), MakeNote(2)]);
+
+        var result = await _controller.GetAll(1);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dtos = ok.Value.Should().BeAssignableTo<IEnumerable<JournalNoteResponseDto>>().Subject;
+        dtos.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetAll_ShouldReturn404_WhenEntryMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((JournalEntry?)null);
+
+        var result = await _controller.GetAll(99);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // ── GetById ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetById_ShouldReturn200_WhenFound()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 5)).ReturnsAsync(MakeNote(5));
+
+        var result = await _controller.Get(1, 5);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<JournalNoteResponseDto>().Subject;
+        dto.Id.Should().Be(5);
+        dto.JournalEntryId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturn404_WhenNoteMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 99)).ReturnsAsync((JournalNote?)null);
+
+        var result = await _controller.Get(1, 99);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturn404_WhenEntryMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((JournalEntry?)null);
+
+        var result = await _controller.Get(99, 1);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // ── Create ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_ShouldReturn201_WhenValid()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<JournalNote>(), default))
+            .ReturnsAsync(new ValidationResult());
+        _noteRepo.Setup(s => s.AddAsync(It.IsAny<JournalNote>()))
+            .ReturnsAsync(MakeNote(7));
+
+        var result = await _controller.Create(1, new CreateJournalNoteDto { Content = "A note" });
+
+        var created = result.Result.Should().BeOfType<CreatedAtRouteResult>().Subject;
+        created.RouteName.Should().Be("GetJournalNoteV1");
+        created.RouteValues.Should().ContainKey("id").WhoseValue.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturn404_WhenEntryMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((JournalEntry?)null);
+
+        var result = await _controller.Create(99, new CreateJournalNoteDto { Content = "x" });
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+        _noteRepo.Verify(s => s.AddAsync(It.IsAny<JournalNote>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturn400_WhenContentIsEmpty()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<JournalNote>(), default))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("Content", "Content is required.")]));
+
+        var result = await _controller.Create(1, new CreateJournalNoteDto { Content = string.Empty });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _noteRepo.Verify(s => s.AddAsync(It.IsAny<JournalNote>()), Times.Never);
+    }
+
+    // ── Update ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_ShouldReturn200_WhenValid()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 3)).ReturnsAsync(MakeNote(3));
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<JournalNote>(), default))
+            .ReturnsAsync(new ValidationResult());
+
+        var result = await _controller.Update(1, 3, new UpdateJournalNoteDto { Content = "Updated" });
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<JournalNoteResponseDto>().Subject;
+        dto.Content.Should().Be("Updated");
+        _noteRepo.Verify(s => s.UpdateAsync(It.IsAny<JournalNote>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturn404_WhenEntryMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((JournalEntry?)null);
+
+        var result = await _controller.Update(99, 1, new UpdateJournalNoteDto { Content = "x" });
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturn404_WhenNoteMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 99)).ReturnsAsync((JournalNote?)null);
+
+        var result = await _controller.Update(1, 99, new UpdateJournalNoteDto { Content = "x" });
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturn400_WhenContentIsEmpty()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 3)).ReturnsAsync(MakeNote(3));
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<JournalNote>(), default))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("Content", "Content is required.")]));
+
+        var result = await _controller.Update(1, 3, new UpdateJournalNoteDto { Content = string.Empty });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _noteRepo.Verify(s => s.UpdateAsync(It.IsAny<JournalNote>()), Times.Never);
+    }
+
+    // ── Delete ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_ShouldReturn204_WhenFound()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 4)).ReturnsAsync(MakeNote(4));
+
+        var result = await _controller.Delete(1, 4);
+
+        result.Should().BeOfType<NoContentResult>();
+        _noteRepo.Verify(s => s.DeleteAsync(1, 4), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldReturn404_WhenEntryMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((JournalEntry?)null);
+
+        var result = await _controller.Delete(99, 1);
+
+        result.Should().BeOfType<NotFoundResult>();
+        _noteRepo.Verify(s => s.DeleteAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldReturn404_WhenNoteMissing()
+    {
+        _entryRepo.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(MakeEntry());
+        _noteRepo.Setup(s => s.GetByIdAsync(1, 99)).ReturnsAsync((JournalNote?)null);
+
+        var result = await _controller.Delete(1, 99);
+
+        result.Should().BeOfType<NotFoundResult>();
+        _noteRepo.Verify(s => s.DeleteAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+}

--- a/TaskFlow.Api.Tests/Repositories/JournalNoteRepositoryTests.cs
+++ b/TaskFlow.Api.Tests/Repositories/JournalNoteRepositoryTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using TaskFlow.Api.Data;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repositories;
+
+namespace TaskFlow.Api.Tests.Repositories;
+
+public class JournalNoteRepositoryTests
+{
+    private static TaskDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<TaskDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new TaskDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetAllByEntryIdAsync_ShouldReturnNotesOrderedByCreatedAt()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        await repo.AddAsync(new JournalNote { JournalEntryId = entry.Id, Content = "First" });
+        await Task.Delay(5);
+        await repo.AddAsync(new JournalNote { JournalEntryId = entry.Id, Content = "Second" });
+
+        var notes = (await repo.GetAllByEntryIdAsync(entry.Id)).ToList();
+
+        notes.Should().HaveCount(2);
+        notes[0].Content.Should().Be("First");
+        notes[1].Content.Should().Be("Second");
+    }
+
+    [Fact]
+    public async Task GetAllByEntryIdAsync_ShouldNotReturnNotesFromOtherEntry()
+    {
+        using var context = CreateInMemoryContext();
+        var entry1 = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        var entry2 = new JournalEntry { Title = "May 28", Date = new DateOnly(2026, 5, 28) };
+        context.JournalEntries.AddRange(entry1, entry2);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        await repo.AddAsync(new JournalNote { JournalEntryId = entry1.Id, Content = "Entry1 note" });
+        await repo.AddAsync(new JournalNote { JournalEntryId = entry2.Id, Content = "Entry2 note" });
+
+        var notes = (await repo.GetAllByEntryIdAsync(entry1.Id)).ToList();
+
+        notes.Should().HaveCount(1);
+        notes[0].Content.Should().Be("Entry1 note");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNote_WhenExists()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        var note = await repo.AddAsync(new JournalNote { JournalEntryId = entry.Id, Content = "Test" });
+
+        var fetched = await repo.GetByIdAsync(entry.Id, note.Id);
+
+        fetched.Should().NotBeNull();
+        fetched!.Content.Should().Be("Test");
+        fetched.JournalEntryId.Should().Be(entry.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+
+        var result = await repo.GetByIdAsync(entry.Id, 9999);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenEntryIdMismatch()
+    {
+        using var context = CreateInMemoryContext();
+        var entry1 = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        var entry2 = new JournalEntry { Title = "May 28", Date = new DateOnly(2026, 5, 28) };
+        context.JournalEntries.AddRange(entry1, entry2);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        var note = await repo.AddAsync(new JournalNote { JournalEntryId = entry1.Id, Content = "Entry1 note" });
+
+        var result = await repo.GetByIdAsync(entry2.Id, note.Id);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldPersistNoteWithId()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        var note = await repo.AddAsync(new JournalNote { JournalEntryId = entry.Id, Content = "New note" });
+
+        note.Id.Should().BeGreaterThan(0);
+        note.CreatedAt.Should().NotBe(default);
+        note.Content.Should().Be("New note");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldSetUpdatedAt()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        var note = await repo.AddAsync(new JournalNote { JournalEntryId = entry.Id, Content = "Original" });
+
+        note.Content = "Updated";
+        await repo.UpdateAsync(note);
+
+        var fetched = await repo.GetByIdAsync(entry.Id, note.Id);
+        fetched.Should().NotBeNull();
+        fetched!.Content.Should().Be("Updated");
+        fetched.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveNote()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+        var note = await repo.AddAsync(new JournalNote { JournalEntryId = entry.Id, Content = "To delete" });
+
+        await repo.DeleteAsync(entry.Id, note.Id);
+
+        var fetched = await repo.GetByIdAsync(entry.Id, note.Id);
+        fetched.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldNotThrow_WhenNoteNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        var entry = new JournalEntry { Title = "May 27", Date = new DateOnly(2026, 5, 27) };
+        context.JournalEntries.Add(entry);
+        await context.SaveChangesAsync();
+
+        var repo = new JournalNoteRepository(context);
+
+        var act = async () => await repo.DeleteAsync(entry.Id, 9999);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/TaskFlow.Api.Tests/Validators/JournalNoteValidatorTests.cs
+++ b/TaskFlow.Api.Tests/Validators/JournalNoteValidatorTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Validators;
+
+namespace TaskFlow.Api.Tests.Validators;
+
+public class JournalNoteValidatorTests
+{
+    private readonly JournalNoteValidator _validator = new();
+
+    [Fact]
+    public async Task Validate_ShouldPass_WhenContentProvided()
+    {
+        var note = new JournalNote { Content = "This is a note", JournalEntryId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_ShouldFail_WhenContentIsEmpty()
+    {
+        var note = new JournalNote { Content = string.Empty, JournalEntryId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Content");
+    }
+
+    [Fact]
+    public async Task Validate_ShouldFail_WhenContentIsWhitespace()
+    {
+        var note = new JournalNote { Content = "   ", JournalEntryId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Content");
+    }
+
+    [Fact]
+    public async Task Validate_ShouldPass_WhenContentExceeds2000Chars()
+    {
+        var note = new JournalNote { Content = new string('x', 2001), JournalEntryId = 1 };
+
+        var result = await _validator.ValidateAsync(note);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/TaskFlow.Api/Controllers/V1/JournalNotesController.cs
+++ b/TaskFlow.Api/Controllers/V1/JournalNotesController.cs
@@ -1,0 +1,135 @@
+using Asp.Versioning;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repositories;
+
+namespace TaskFlow.Api.Controllers.V1;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/JournalEntries/{entryId}/notes")]
+public class JournalNotesController(
+    IJournalEntryRepository journalRepo,
+    IJournalNoteRepository noteRepo,
+    IValidator<JournalNote> validator) : ControllerBase
+{
+    private const string GetNoteRouteName = "GetJournalNoteV1";
+    private const string ApiVersionString = "1.0";
+    private readonly IJournalEntryRepository _journalRepo = journalRepo;
+    private readonly IJournalNoteRepository _noteRepo = noteRepo;
+    private readonly IValidator<JournalNote> _validator = validator;
+
+    // GET: api/v1/JournalEntries/{entryId}/notes
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<JournalNoteResponseDto>>> GetAll(int entryId)
+    {
+        var entry = await _journalRepo.GetByIdAsync(entryId);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        var notes = await _noteRepo.GetAllByEntryIdAsync(entryId);
+        return Ok(notes.Select(ToDto));
+    }
+
+    // GET: api/v1/JournalEntries/{entryId}/notes/{id}
+    [HttpGet("{id}", Name = GetNoteRouteName)]
+    public async Task<ActionResult<JournalNoteResponseDto>> Get(int entryId, int id)
+    {
+        var entry = await _journalRepo.GetByIdAsync(entryId);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        var note = await _noteRepo.GetByIdAsync(entryId, id);
+        if (note is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToDto(note));
+    }
+
+    // POST: api/v1/JournalEntries/{entryId}/notes
+    [HttpPost]
+    public async Task<ActionResult<JournalNoteResponseDto>> Create(int entryId, [FromBody] CreateJournalNoteDto dto)
+    {
+        var entry = await _journalRepo.GetByIdAsync(entryId);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        var note = new JournalNote { Content = dto.Content, JournalEntryId = entryId };
+
+        var validation = await _validator.ValidateAsync(note);
+        if (!validation.IsValid)
+        {
+            return BadRequest(validation.Errors);
+        }
+
+        var created = await _noteRepo.AddAsync(note);
+        return CreatedAtRoute(GetNoteRouteName, new { version = ApiVersionString, entryId, id = created.Id }, ToDto(created));
+    }
+
+    // PUT: api/v1/JournalEntries/{entryId}/notes/{id}
+    [HttpPut("{id}")]
+    public async Task<ActionResult<JournalNoteResponseDto>> Update(int entryId, int id, [FromBody] UpdateJournalNoteDto dto)
+    {
+        var entry = await _journalRepo.GetByIdAsync(entryId);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        var existing = await _noteRepo.GetByIdAsync(entryId, id);
+        if (existing is null)
+        {
+            return NotFound();
+        }
+
+        existing.Content = dto.Content;
+
+        var validation = await _validator.ValidateAsync(existing);
+        if (!validation.IsValid)
+        {
+            return BadRequest(validation.Errors);
+        }
+
+        await _noteRepo.UpdateAsync(existing);
+        return Ok(ToDto(existing));
+    }
+
+    // DELETE: api/v1/JournalEntries/{entryId}/notes/{id}
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int entryId, int id)
+    {
+        var entry = await _journalRepo.GetByIdAsync(entryId);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        var existing = await _noteRepo.GetByIdAsync(entryId, id);
+        if (existing is null)
+        {
+            return NotFound();
+        }
+
+        await _noteRepo.DeleteAsync(entryId, id);
+        return NoContent();
+    }
+
+    private static JournalNoteResponseDto ToDto(JournalNote n) => new()
+    {
+        Id = n.Id,
+        Content = n.Content,
+        JournalEntryId = n.JournalEntryId,
+        CreatedAt = n.CreatedAt,
+        UpdatedAt = n.UpdatedAt,
+    };
+}

--- a/TaskFlow.Api/DTOs/CreateJournalNoteDto.cs
+++ b/TaskFlow.Api/DTOs/CreateJournalNoteDto.cs
@@ -1,0 +1,6 @@
+namespace TaskFlow.Api.DTOs;
+
+public class CreateJournalNoteDto
+{
+    public required string Content { get; set; }
+}

--- a/TaskFlow.Api/DTOs/JournalNoteResponseDto.cs
+++ b/TaskFlow.Api/DTOs/JournalNoteResponseDto.cs
@@ -1,0 +1,10 @@
+namespace TaskFlow.Api.DTOs;
+
+public class JournalNoteResponseDto
+{
+    public int Id { get; set; }
+    public required string Content { get; set; }
+    public int JournalEntryId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/TaskFlow.Api/DTOs/UpdateJournalNoteDto.cs
+++ b/TaskFlow.Api/DTOs/UpdateJournalNoteDto.cs
@@ -1,0 +1,6 @@
+namespace TaskFlow.Api.DTOs;
+
+public class UpdateJournalNoteDto
+{
+    public required string Content { get; set; }
+}

--- a/TaskFlow.Api/Data/TaskDbContext.cs
+++ b/TaskFlow.Api/Data/TaskDbContext.cs
@@ -10,6 +10,7 @@ public class TaskDbContext(DbContextOptions<TaskDbContext> options) : DbContext(
     public DbSet<Note> Notes => Set<Note>();
     public DbSet<JournalEntry> JournalEntries => Set<JournalEntry>();
     public DbSet<JournalLogEntry> JournalLogEntries => Set<JournalLogEntry>();
+    public DbSet<JournalNote> JournalNotes => Set<JournalNote>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -64,6 +65,11 @@ public class TaskDbContext(DbContextOptions<TaskDbContext> options) : DbContext(
             entity.HasMany(e => e.Todos)
                   .WithMany()
                   .UsingEntity("JournalEntryTaskItem");
+
+            entity.HasMany(e => e.Notes)
+                  .WithOne(n => n.JournalEntry)
+                  .HasForeignKey(n => n.JournalEntryId)
+                  .OnDelete(DeleteBehavior.Cascade);
         });
     }
 }

--- a/TaskFlow.Api/Extensions/PersistenceServiceExtensions.cs
+++ b/TaskFlow.Api/Extensions/PersistenceServiceExtensions.cs
@@ -32,6 +32,7 @@ public static class PersistenceServiceExtensions
         services.AddScoped<INoteRepository, NoteRepository>();
         services.AddScoped<IJournalEntryRepository, JournalEntryRepository>();
         services.AddScoped<IJournalLogEntryRepository, JournalLogEntryRepository>();
+        services.AddScoped<IJournalNoteRepository, JournalNoteRepository>();
 
         return services;
     }

--- a/TaskFlow.Api/Migrations/20260528031541_AddJournalNotes.Designer.cs
+++ b/TaskFlow.Api/Migrations/20260528031541_AddJournalNotes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TaskFlow.Api.Data;
 
@@ -10,9 +11,11 @@ using TaskFlow.Api.Data;
 namespace TaskFlow.Api.Migrations
 {
     [DbContext(typeof(TaskDbContext))]
-    partial class TaskDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528031541_AddJournalNotes")]
+    partial class AddJournalNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/TaskFlow.Api/Migrations/20260528031541_AddJournalNotes.cs
+++ b/TaskFlow.Api/Migrations/20260528031541_AddJournalNotes.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TaskFlow.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddJournalNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "JournalNotes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    JournalEntryId = table.Column<int>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_JournalNotes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_JournalNotes_JournalEntries_JournalEntryId",
+                        column: x => x.JournalEntryId,
+                        principalTable: "JournalEntries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JournalNotes_JournalEntryId",
+                table: "JournalNotes",
+                column: "JournalEntryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "JournalNotes");
+        }
+    }
+}

--- a/TaskFlow.Api/Models/JournalEntry.cs
+++ b/TaskFlow.Api/Models/JournalEntry.cs
@@ -10,4 +10,5 @@ public class JournalEntry
     public DateTime? UpdatedAt { get; set; }
     public ICollection<TaskItem> Todos { get; set; } = [];
     public ICollection<JournalLogEntry> LogEntries { get; set; } = [];
+    public ICollection<JournalNote> Notes { get; set; } = [];
 }

--- a/TaskFlow.Api/Models/JournalNote.cs
+++ b/TaskFlow.Api/Models/JournalNote.cs
@@ -1,0 +1,11 @@
+namespace TaskFlow.Api.Models;
+
+public class JournalNote
+{
+    public int Id { get; set; }
+    public required string Content { get; set; }
+    public int JournalEntryId { get; set; }
+    public JournalEntry JournalEntry { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/TaskFlow.Api/Repositories/IJournalNoteRepository.cs
+++ b/TaskFlow.Api/Repositories/IJournalNoteRepository.cs
@@ -1,0 +1,12 @@
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Repositories;
+
+public interface IJournalNoteRepository
+{
+    Task<IEnumerable<JournalNote>> GetAllByEntryIdAsync(int entryId);
+    Task<JournalNote?> GetByIdAsync(int entryId, int id);
+    Task<JournalNote> AddAsync(JournalNote note);
+    Task UpdateAsync(JournalNote note);
+    Task DeleteAsync(int entryId, int id);
+}

--- a/TaskFlow.Api/Repositories/JournalNoteRepository.cs
+++ b/TaskFlow.Api/Repositories/JournalNoteRepository.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using TaskFlow.Api.Data;
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Repositories;
+
+public class JournalNoteRepository(TaskDbContext context) : IJournalNoteRepository
+{
+    private readonly TaskDbContext _context = context;
+
+    public async Task<IEnumerable<JournalNote>> GetAllByEntryIdAsync(int entryId) =>
+        await _context.JournalNotes
+            .Where(n => n.JournalEntryId == entryId)
+            .OrderBy(n => n.CreatedAt)
+            .ToListAsync();
+
+    public async Task<JournalNote?> GetByIdAsync(int entryId, int id) =>
+        await _context.JournalNotes
+            .FirstOrDefaultAsync(n => n.Id == id && n.JournalEntryId == entryId);
+
+    public async Task<JournalNote> AddAsync(JournalNote note)
+    {
+        note.CreatedAt = DateTime.UtcNow;
+        _context.JournalNotes.Add(note);
+        await _context.SaveChangesAsync();
+        return note;
+    }
+
+    public async Task UpdateAsync(JournalNote note)
+    {
+        note.UpdatedAt = DateTime.UtcNow;
+        _context.JournalNotes.Update(note);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int entryId, int id)
+    {
+        var note = await _context.JournalNotes
+            .FirstOrDefaultAsync(n => n.Id == id && n.JournalEntryId == entryId);
+        if (note is null)
+        {
+            return;
+        }
+
+        _context.JournalNotes.Remove(note);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/TaskFlow.Api/Validators/JournalNoteValidator.cs
+++ b/TaskFlow.Api/Validators/JournalNoteValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Validators;
+
+public class JournalNoteValidator : AbstractValidator<JournalNote>
+{
+    public JournalNoteValidator()
+    {
+        RuleFor(n => n.Content)
+            .NotEmpty().WithMessage("Content is required.");
+    }
+}

--- a/TaskFlow.Web/src/api/journal.ts
+++ b/TaskFlow.Web/src/api/journal.ts
@@ -79,3 +79,31 @@ export const deleteLogEntry = (entryId: number, logId: number) =>
   client.delete<{ 204: unknown }, unknown, true>(
     { url: '/api/v1/JournalEntries/{entryId}/logs/{id}', path: { entryId, id: logId } },
   )
+
+export type JournalNoteResponseDto = {
+  id: number
+  content: string
+  journalEntryId: number
+  createdAt: string
+  updatedAt?: string | null
+}
+
+export const getJournalNotes = (entryId: number) =>
+  client.get<{ 200: JournalNoteResponseDto[] }, unknown, true>(
+    { url: '/api/v1/JournalEntries/{entryId}/notes', path: { entryId } },
+  )
+
+export const createJournalNote = (entryId: number, content: string) =>
+  client.post<{ 201: JournalNoteResponseDto }, unknown, true>(
+    { url: '/api/v1/JournalEntries/{entryId}/notes', path: { entryId }, body: { content }, headers: J },
+  )
+
+export const updateJournalNote = (entryId: number, id: number, content: string) =>
+  client.put<{ 200: JournalNoteResponseDto }, unknown, true>(
+    { url: '/api/v1/JournalEntries/{entryId}/notes/{id}', path: { entryId, id }, body: { content }, headers: J },
+  )
+
+export const deleteJournalNote = (entryId: number, id: number) =>
+  client.delete<{ 204: unknown }, unknown, true>(
+    { url: '/api/v1/JournalEntries/{entryId}/notes/{id}', path: { entryId, id } },
+  )

--- a/TaskFlow.Web/src/components/journal/NotesSection.tsx
+++ b/TaskFlow.Web/src/components/journal/NotesSection.tsx
@@ -1,63 +1,114 @@
-import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react'
-import { useUpdateNotesMutation } from '@/hooks/useJournal'
+import { useState, useRef, forwardRef, useImperativeHandle } from 'react'
+import type { JournalNoteResponseDto } from '@/api/journal'
+import {
+  useJournalNotes,
+  useCreateJournalNoteMutation,
+  useUpdateJournalNoteMutation,
+  useDeleteJournalNoteMutation,
+} from '@/hooks/useJournal'
+import { formatTime } from '@/lib/journal-utils'
 
 interface Props {
   entryId: number
-  entryTitle: string
-  initialValue: string | null | undefined
 }
 
 export interface NotesSectionHandle {
-  focusNotes: () => void
+  focusNewNote: () => void
 }
 
-export const NotesSection = forwardRef<NotesSectionHandle, Props>(function NotesSection({ entryId, entryTitle, initialValue }, ref) {
-  const [value, setValue] = useState(initialValue ?? '')
-  const [savedAt, setSavedAt] = useState<number | null>(null)
-  const updateNotes = useUpdateNotesMutation(entryId, entryTitle)
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
+export const NotesSection = forwardRef<NotesSectionHandle, Props>(function NotesSection({ entryId }, ref) {
+  const { data: notes = [] } = useJournalNotes(entryId)
+  const createNote = useCreateJournalNoteMutation(entryId)
+  const updateNote = useUpdateJournalNoteMutation(entryId)
+  const deleteNote = useDeleteJournalNoteMutation(entryId)
+
+  const [draft, setDraft] = useState('')
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editingText, setEditingText] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useImperativeHandle(ref, () => ({
-    focusNotes: () => textareaRef.current?.focus(),
+    focusNewNote: () => inputRef.current?.focus(),
   }))
 
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
-    }
-  }, [entryId])
-
-  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    const next = e.target.value
-    setValue(next)
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => {
-      updateNotes.mutate(next, { onSuccess: () => setSavedAt(Date.now()) })
-    }, 600)
+  function addNote(e: React.FormEvent) {
+    e.preventDefault()
+    const text = draft.trim()
+    if (!text) return
+    createNote.mutate(text, { onSuccess: () => inputRef.current?.focus() })
+    setDraft('')
   }
 
-  const wordCount = value.trim().split(/\s+/).filter(Boolean).length
+  function startEdit(note: JournalNoteResponseDto) {
+    setEditingId(note.id)
+    setEditingText(note.content)
+  }
+
+  function commitEdit(noteId: number, original: string) {
+    const text = editingText.trim()
+    if (text && text !== original) {
+      updateNote.mutate({ id: noteId, content: text })
+    }
+    setEditingId(null)
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+  }
 
   return (
     <section className="card notes-section">
-      <div className="card-hdr">
-        <h2 className="card-title">Notes</h2>
-        <div className="card-meta">
-          <span className="word-count">{wordCount} words</span>
-          {savedAt && <span className="saved">Saved</span>}
-        </div>
-      </div>
-      <textarea
-        ref={textareaRef}
-        className="notes-area"
-        placeholder="Free-form notes for the day — observations, decisions, follow-ups, anything."
-        value={value}
-        onChange={handleChange}
-        onKeyDown={e => {
-          if (e.key === 'Escape') textareaRef.current?.blur()
-        }}
-      />
+      <ol className="log-list">
+        {notes.length === 0 && (
+          <li className="j-empty">No notes yet — capture anything below.</li>
+        )}
+        {notes.map(note => (
+          <li key={note.id} className="log-entry">
+            <div className="log-time">{formatTime(note.createdAt)}</div>
+            {editingId === note.id ? (
+              <input
+                className="note-edit"
+                value={editingText}
+                autoFocus
+                onChange={e => setEditingText(e.target.value)}
+                onBlur={() => commitEdit(note.id, note.content)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') { e.preventDefault(); commitEdit(note.id, note.content) }
+                  if (e.key === 'Escape') cancelEdit()
+                }}
+              />
+            ) : (
+              <div className="note-text" onDoubleClick={() => startEdit(note)}>
+                {note.content}
+              </div>
+            )}
+            <button
+              className="todo-x"
+              onClick={() => deleteNote.mutate(note.id)}
+              aria-label="Delete note"
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+                <path d="M18 6L6 18M6 6l12 12"/>
+              </svg>
+            </button>
+          </li>
+        ))}
+      </ol>
+
+      <form className="add-row" onSubmit={addNote}>
+        <span className="add-plus">›</span>
+        <input
+          ref={inputRef}
+          className="add-input"
+          placeholder="Add a note… Press Enter to save"
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          disabled={createNote.isPending}
+          onKeyDown={e => {
+            if (e.key === 'Escape') { setDraft(''); inputRef.current?.blur() }
+          }}
+        />
+      </form>
     </section>
   )
 })

--- a/TaskFlow.Web/src/hooks/useJournal.ts
+++ b/TaskFlow.Web/src/hooks/useJournal.ts
@@ -8,8 +8,12 @@ import {
   removeJournalTodo,
   createLogEntry,
   deleteLogEntry,
+  getJournalNotes,
+  createJournalNote,
+  updateJournalNote,
+  deleteJournalNote,
 } from '@/api/journal'
-import type { JournalEntryResponseDto, TaskItemResponseDto } from '@/api/journal'
+import type { JournalEntryResponseDto, TaskItemResponseDto, JournalNoteResponseDto } from '@/api/journal'
 import type { CreateTaskItemDto, UpdateTaskItemDto } from '@/api/client/types.gen'
 import { postApiV1TaskItems, putApiV1TaskItemsById } from '@/api/client/sdk.gen'
 import { taskKeys } from '@/hooks/useTasks'
@@ -19,6 +23,7 @@ import { usePrefs } from '@/context/usePrefs'
 export const journalKeys = {
   all: ['journal'] as const,
   todos: (entryId: number) => ['journal', entryId, 'todos'] as const,
+  notes: (entryId: number) => ['journal', entryId, 'notes'] as const,
 }
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
@@ -72,14 +77,38 @@ export function useEnsureJournalEntry(isoDate: string) {
   }
 }
 
-// ─── Journal entry mutations ──────────────────────────────────────────────────
+// ─── Journal notes queries and mutations ─────────────────────────────────────
 
-export function useUpdateNotesMutation(entryId: number, entryTitle: string) {
+export function useJournalNotes(entryId: number) {
+  return useQuery({
+    queryKey: journalKeys.notes(entryId),
+    queryFn: () => getJournalNotes(entryId),
+    select: (res) => (res.data as JournalNoteResponseDto[] | undefined) ?? [],
+  })
+}
+
+export function useCreateJournalNoteMutation(entryId: number) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (summary: string) =>
-      updateJournalEntry(entryId, { title: entryTitle, summary }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: journalKeys.all }),
+    mutationFn: (content: string) => createJournalNote(entryId, content),
+    onSuccess: () => qc.invalidateQueries({ queryKey: journalKeys.notes(entryId) }),
+  })
+}
+
+export function useUpdateJournalNoteMutation(entryId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, content }: { id: number; content: string }) =>
+      updateJournalNote(entryId, id, content),
+    onSuccess: () => qc.invalidateQueries({ queryKey: journalKeys.notes(entryId) }),
+  })
+}
+
+export function useDeleteJournalNoteMutation(entryId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => deleteJournalNote(entryId, id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: journalKeys.notes(entryId) }),
   })
 }
 

--- a/TaskFlow.Web/src/hooks/useJournal.ts
+++ b/TaskFlow.Web/src/hooks/useJournal.ts
@@ -3,7 +3,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   getJournalEntries,
   createJournalEntry,
-  updateJournalEntry,
   getJournalTodos,
   removeJournalTodo,
   createLogEntry,

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
@@ -7,7 +7,7 @@ function makeHandlers(): JournalShortcutHandlers {
   return {
     onNewTodo: vi.fn(),
     onNewLog: vi.fn(),
-    onFocusNotes: vi.fn(),
+    onNewNote: vi.fn(),
     onPrevDay: vi.fn(),
     onNextDay: vi.fn(),
     onGoHome: vi.fn(),
@@ -45,10 +45,10 @@ describe('useJournalKeyboardShortcuts', () => {
     expect(handlers.onNewLog).toHaveBeenCalledOnce()
   })
 
-  it('fires onFocusNotes when n is pressed', () => {
+  it('fires onNewNote when n is pressed', () => {
     renderHook(() => useJournalKeyboardShortcuts(handlers))
     fireKey('n')
-    expect(handlers.onFocusNotes).toHaveBeenCalledOnce()
+    expect(handlers.onNewNote).toHaveBeenCalledOnce()
   })
 
   it('fires onPrevDay when [ is pressed', () => {
@@ -84,7 +84,7 @@ describe('useJournalKeyboardShortcuts', () => {
 
     expect(handlers.onNewTodo).not.toHaveBeenCalled()
     expect(handlers.onNewLog).not.toHaveBeenCalled()
-    expect(handlers.onFocusNotes).not.toHaveBeenCalled()
+    expect(handlers.onNewNote).not.toHaveBeenCalled()
     expect(handlers.onPrevDay).not.toHaveBeenCalled()
     expect(handlers.onNextDay).not.toHaveBeenCalled()
     expect(handlers.onShowHelp).not.toHaveBeenCalled()

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
@@ -3,7 +3,7 @@ import { useEffect, useLayoutEffect, useRef } from 'react'
 export interface JournalShortcutHandlers {
   onNewTodo: () => void
   onNewLog: () => void
-  onFocusNotes: () => void
+  onNewNote: () => void
   onPrevDay: () => void
   onNextDay: () => void
   onGoHome: () => void
@@ -80,7 +80,7 @@ export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
           break
         case 'n':
           e.preventDefault()
-          handlersRef.current.onFocusNotes()
+          handlersRef.current.onNewNote()
           break
         case '[':
           e.preventDefault()

--- a/TaskFlow.Web/src/journal.css
+++ b/TaskFlow.Web/src/journal.css
@@ -570,28 +570,25 @@
   min-height: auto;
   border-top: 0;
 }
-.notes-area {
+.note-text {
   flex: 1;
-  width: 100%;
-  min-height: calc(140px * var(--den));
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--paper-2);
-  background-image: linear-gradient(transparent calc(1.5em - 1px), color-mix(in oklab, var(--accent) 10%, transparent) 1px);
-  background-size: 100% 1.5em;
-  line-height: 1.5em;
-  padding: 12px 16px;
-  resize: vertical;
-  outline: none;
   font-size: 14.5px;
   color: var(--ink);
-  transition: border-color .12s, box-shadow .12s;
+  cursor: text;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.notes-area:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent);
+.journal-page .note-edit {
+  flex: 1;
+  border: 0;
+  border-bottom: 1.5px solid var(--accent);
+  background: transparent;
+  outline: none;
+  padding: 2px 0;
+  font-size: 14.5px;
 }
-.notes-area::placeholder { color: var(--muted-2); font-style: italic; }
 
 /* ─── Loading / error states ───────────────────────────────────────────────── */
 

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -40,7 +40,7 @@ export function JournalPage() {
   useJournalKeyboardShortcuts({
     onNewTodo: () => todosSectionRef.current?.focusDraftInput(),
     onNewLog: () => logSectionRef.current?.focusDraftInput(),
-    onFocusNotes: () => notesSectionRef.current?.focusNotes(),
+    onNewNote: () => notesSectionRef.current?.focusNewNote(),
     onPrevDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, -1))}`),
     onNextDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, 1))}`),
     onGoHome: () => navigate(`/journal/${isoToUrlDate(todayISO())}`),
@@ -84,8 +84,6 @@ export function JournalPage() {
                 ref={notesSectionRef}
                 key={entry.id}
                 entryId={entry.id}
-                entryTitle={entry.title}
-                initialValue={entry.summary}
               />
             </>
           ) : null}


### PR DESCRIPTION
## Summary

- Replaces `JournalEntry.Summary` (single textarea) with a list of discrete `JournalNote` records per journal entry
- Notes are ordered by creation time, editable inline via double-click (matching the todo pattern), and each shows a creation timestamp
- The `n` keyboard shortcut now focuses the new-note draft input
- New REST API: `GET/POST/PUT/DELETE /api/v1/JournalEntries/{entryId}/notes`
- `JournalNote` entity with EF Core migration and cascade delete; `JournalNoteValidator` with no length cap (required content only)
- `NotesSection` fully rewritten from single textarea to per-note list with inline editing; `onFocusNotes` renamed to `onNewNote` throughout

## Test plan

- [ ] `dotnet test TaskFlow.sln` — 221 tests pass
- [ ] `npx tsc --noEmit` — no TypeScript errors
- [ ] Press `n` shortcut — draft input at bottom of notes section receives focus
- [ ] Type a note and press Enter — note appears in list with timestamp
- [ ] Double-click a note — inline edit input; Enter/blur saves, Escape cancels
- [ ] Click x on a note — note is deleted
- [ ] Reload page — notes persist
- [ ] Navigate to a day with no notes — empty state placeholder shown
- [ ] Regression: todos (t), daily log (l), other shortcuts still work

Generated with Claude Code