### PR TITLE
chore: document Bash/PowerShell tool split and ripgrep availability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,22 @@ docker compose up -d
 docker compose -f docker-compose.prod.yml up
 ```
 
+## Shell & Command Execution
+
+Two execution tools are available on this Windows machine:
+
+- **Bash tool** — runs POSIX shell (WSL/Git Bash). Use for cross-platform CLIs: `git`, `npm`, `dotnet`, `docker`, `gh`, `node`, `python3`.
+- **PowerShell tool** — runs `pwsh`. Use for Windows operations requiring PowerShell cmdlets.
+
+**Never mix them:** Do not run `Get-ChildItem`, `Test-Path`, or `Select-String` through the Bash tool. Do not run `grep`, `find`, `xargs`, `sed`, `awk`, or `head`/`tail` through the PowerShell tool.
+
+**`rg` (ripgrep) is installed natively on Windows** — works in both Bash and PowerShell without WSL. Use it when a shell-level content search is needed and the Grep tool is not appropriate.
+
+**Prefer dedicated tools over shell commands:**
+- Find files → Glob tool (not `find` or `Get-ChildItem`)
+- Search content → Grep tool (not `grep` or `Select-String`); shell fallback: `rg`
+- Read files → Read tool (not `cat` or `Get-Content`)
+
 ## Architecture
 
 **Layered flow:** `Controller → Repository → EF Core (SQLite)`


### PR DESCRIPTION
## Summary

- Adds a **Shell & Command Execution** section to `CLAUDE.md` between `## Commands` and `## Architecture`
- Explicitly defines when to use the Bash tool (WSL/Git Bash — for cross-platform CLIs) vs. the PowerShell tool (pwsh — for Windows cmdlets)
- Documents that `rg` (ripgrep) is installed natively on Windows and works in both shells without WSL
- Provides a quick-reference list: prefer Glob/Grep/Read tools over shell commands, with `rg` as the shell fallback for content search

## Problem solved

Claude was repeatedly generating commands with the wrong shell syntax — using PowerShell cmdlets through the Bash tool or bash-style commands through PowerShell — then getting errors and rewriting on retry. Without explicit project-level guidance, Claude had to guess which tool to use each time.

The `settings.local.json` permission entries for `Get-ChildItem`, `Select-String`, `Test-Path`, and `rg` were also corrected locally (that file is gitignored, so the fix is applied locally only).

## Test plan

- [ ] Start a new conversation in this project
- [ ] Ask Claude to search for a file or run a command that would have previously triggered a shell mismatch
- [ ] Confirm it succeeds on the first attempt without a retry rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)