### PR TITLE
feat: lift keyboard shortcuts to work on all pages

### DIFF
--- a/TaskFlow.Web/src/components/KeyboardShortcutsModal.test.tsx
+++ b/TaskFlow.Web/src/components/KeyboardShortcutsModal.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { KeyboardShortcutsModal } from './KeyboardShortcutsModal'
+
+function renderModal(onClose = vi.fn()) {
+  return render(<KeyboardShortcutsModal onClose={onClose} />)
+}
+
+describe('KeyboardShortcutsModal', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.overflow = ''
+  })
+
+  it('renders the Navigation (all pages) group with g→h, g→t, and ? shortcuts', () => {
+    renderModal()
+    expect(screen.getByText('Navigation (all pages)')).toBeInTheDocument()
+    expect(screen.getByText('Go to today (home)')).toBeInTheDocument()
+    expect(screen.getByText('Go to tasks page')).toBeInTheDocument()
+    expect(screen.getByText('Show / hide this help')).toBeInTheDocument()
+  })
+
+  it('renders the Journal — Day Navigation group with [ and ] shortcuts', () => {
+    renderModal()
+    expect(screen.getByText('Journal — Day Navigation')).toBeInTheDocument()
+    expect(screen.getByText('Previous day')).toBeInTheDocument()
+    expect(screen.getByText('Next day')).toBeInTheDocument()
+  })
+
+  it('renders the Journal — Actions group with t, l, and n shortcuts', () => {
+    renderModal()
+    expect(screen.getByText('Journal — Actions')).toBeInTheDocument()
+    expect(screen.getByText('New todo')).toBeInTheDocument()
+    expect(screen.getByText('New log entry')).toBeInTheDocument()
+    expect(screen.getByText('Focus notes')).toBeInTheDocument()
+  })
+
+  it('renders the Inputs group with Esc shortcut', () => {
+    renderModal()
+    expect(screen.getByText('Inputs')).toBeInTheDocument()
+    expect(screen.getByText('Cancel / deselect focused field')).toBeInTheDocument()
+  })
+
+  it('calls onClose when the Close button is clicked', async () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when ? is pressed', () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('traps Tab focus on the Close button', async () => {
+    renderModal()
+    const closeBtn = screen.getByRole('button', { name: /close/i })
+    await userEvent.tab()
+    expect(closeBtn).toHaveFocus()
+  })
+
+  it('sets body overflow to hidden while open', () => {
+    renderModal()
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('restores body overflow and returns focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Open'
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    document.body.style.overflow = ''
+
+    const { unmount } = renderModal()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmount()
+
+    expect(document.body.style.overflow).toBe('')
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/TaskFlow.Web/src/components/KeyboardShortcutsModal.tsx
+++ b/TaskFlow.Web/src/components/KeyboardShortcutsModal.tsx
@@ -6,21 +6,26 @@ interface Props {
 
 const SHORTCUTS = [
   {
-    group: 'Actions',
+    group: 'Navigation (all pages)',
     items: [
-      { keys: ['t'], description: 'New todo' },
-      { keys: ['l'], description: 'New log entry' },
-      { keys: ['n'], description: 'Focus notes' },
+      { keys: ['g', 'h'], description: 'Go to today (home)' },
+      { keys: ['g', 't'], description: 'Go to tasks page' },
       { keys: ['?'], description: 'Show / hide this help' },
     ],
   },
   {
-    group: 'Navigation',
+    group: 'Journal — Day Navigation',
     items: [
       { keys: ['['], description: 'Previous day' },
       { keys: [']'], description: 'Next day' },
-      { keys: ['g', 'h'], description: 'Go to today (home)' },
-      { keys: ['g', 't'], description: 'Go to tasks page' },
+    ],
+  },
+  {
+    group: 'Journal — Actions',
+    items: [
+      { keys: ['t'], description: 'New todo' },
+      { keys: ['l'], description: 'New log entry' },
+      { keys: ['n'], description: 'Focus notes' },
     ],
   },
   {

--- a/TaskFlow.Web/src/components/Layout.test.tsx
+++ b/TaskFlow.Web/src/components/Layout.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, within, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { PrefsProvider } from '@/context/PrefsContext'
+import { Layout } from './Layout'
+import type { GlobalShortcutHandlers } from '@/hooks/useGlobalKeyboardShortcuts'
+
+// Capture the handlers and options that Layout passes to the hook
+let capturedHandlers: GlobalShortcutHandlers | null = null
+let capturedDisabled: boolean | undefined = undefined
+
+vi.mock('@/hooks/useGlobalKeyboardShortcuts', () => ({
+  useGlobalKeyboardShortcuts: (
+    handlers: GlobalShortcutHandlers,
+    options?: { disabled?: boolean },
+  ) => {
+    capturedHandlers = handlers
+    capturedDisabled = options?.disabled
+  },
+}))
+
+// Mock child components that need complex context to render
+vi.mock('@/components/Nav', () => ({
+  Nav: ({ onMenuClick }: { onMenuClick: () => void }) => (
+    <nav data-testid="nav">
+      <button onClick={onMenuClick}>Menu</button>
+    </nav>
+  ),
+}))
+
+vi.mock('@/components/SettingsDrawer', () => ({
+  SettingsDrawer: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
+    <div data-testid="settings-drawer" data-open={String(open)}>
+      <button onClick={onClose}>Close Drawer</button>
+    </div>
+  ),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    Outlet: () => <div data-testid="outlet" />,
+  }
+})
+
+function renderLayout() {
+  return render(
+    <MemoryRouter>
+      <PrefsProvider>
+        <Layout />
+      </PrefsProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('Layout', () => {
+  beforeEach(() => {
+    capturedHandlers = null
+    capturedDisabled = undefined
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders Nav, SettingsDrawer, and Outlet', () => {
+    renderLayout()
+    expect(screen.getByTestId('nav')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-drawer')).toBeInTheDocument()
+    expect(screen.getByTestId('outlet')).toBeInTheDocument()
+  })
+
+  it('does not render KeyboardShortcutsModal by default', () => {
+    renderLayout()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders KeyboardShortcutsModal when onShowHelp is triggered', () => {
+    renderLayout()
+    act(() => {
+      capturedHandlers?.onShowHelp()
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument()
+  })
+
+  it('hides KeyboardShortcutsModal when its onClose is called', async () => {
+    renderLayout()
+    act(() => {
+      capturedHandlers?.onShowHelp()
+    })
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    await userEvent.click(within(dialog).getByRole('button', { name: /close/i }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('passes disabled={true} to useGlobalKeyboardShortcuts when the drawer is open', async () => {
+    renderLayout()
+    // Initially closed
+    expect(capturedDisabled).toBe(false)
+    // Open the drawer
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }))
+    expect(capturedDisabled).toBe(true)
+  })
+
+  it('passes disabled={false} to useGlobalKeyboardShortcuts when the drawer is closed', () => {
+    renderLayout()
+    expect(capturedDisabled).toBe(false)
+  })
+
+  it('closes KeyboardShortcutsModal when ? is pressed while modal is open', () => {
+    renderLayout()
+    act(() => {
+      capturedHandlers?.onShowHelp()
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/TaskFlow.Web/src/components/Layout.tsx
+++ b/TaskFlow.Web/src/components/Layout.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useNavigate } from 'react-router-dom'
 import { Nav } from '@/components/Nav'
 import { SettingsDrawer } from '@/components/SettingsDrawer'
+import { KeyboardShortcutsModal } from '@/components/KeyboardShortcutsModal'
+import { useGlobalKeyboardShortcuts } from '@/hooks/useGlobalKeyboardShortcuts'
 import { usePrefs } from '@/context/usePrefs'
+import { todayUrlDate } from '@/lib/journal-utils'
 import type { SortMode, HeaderStyle } from '@/lib/prefs'
 
 export interface AppContext {
@@ -21,12 +24,24 @@ export interface AppContext {
 export function Layout() {
   const prefs = usePrefs()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [showShortcuts, setShowShortcuts] = useState(false)
+  const navigate = useNavigate()
+
+  useGlobalKeyboardShortcuts(
+    {
+      onGoHome: () => navigate(`/journal/${todayUrlDate()}`),
+      onGoTasks: () => navigate('/tasks'),
+      onShowHelp: () => setShowShortcuts(true),
+    },
+    { disabled: drawerOpen || showShortcuts },
+  )
 
   return (
     <>
       <Nav onMenuClick={() => setDrawerOpen(true)} />
       <SettingsDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
       <Outlet context={prefs satisfies AppContext} />
+      {showShortcuts && <KeyboardShortcutsModal onClose={() => setShowShortcuts(false)} />}
     </>
   )
 }

--- a/TaskFlow.Web/src/hooks/useGlobalKeyboardShortcuts.test.ts
+++ b/TaskFlow.Web/src/hooks/useGlobalKeyboardShortcuts.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useGlobalKeyboardShortcuts } from './useGlobalKeyboardShortcuts'
+import type { GlobalShortcutHandlers } from './useGlobalKeyboardShortcuts'
+
+function makeHandlers(): GlobalShortcutHandlers {
+  return {
+    onGoHome: vi.fn(),
+    onGoTasks: vi.fn(),
+    onShowHelp: vi.fn(),
+  }
+}
+
+function fireKey(key: string, options: KeyboardEventInit = {}) {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...options }))
+}
+
+describe('useGlobalKeyboardShortcuts', () => {
+  let handlers: GlobalShortcutHandlers
+
+  beforeEach(() => {
+    handlers = makeHandlers()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('fires onShowHelp when ? is pressed with no input focused', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
+  })
+
+  it('does not fire onShowHelp when an input is focused', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('?')
+    expect(handlers.onShowHelp).not.toHaveBeenCalled()
+  })
+
+  it('does not fire onShowHelp when a textarea is focused', () => {
+    const ta = document.createElement('textarea')
+    document.body.appendChild(ta)
+    ta.focus()
+
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('?')
+    expect(handlers.onShowHelp).not.toHaveBeenCalled()
+  })
+
+  it('does not fire shortcuts when modifier keys are held (Ctrl, Alt, Meta)', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('?', { ctrlKey: true })
+    fireKey('?', { altKey: true })
+    fireKey('?', { metaKey: true })
+    expect(handlers.onShowHelp).not.toHaveBeenCalled()
+  })
+
+  it('g then h within 1.5s triggers onGoHome', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    vi.advanceTimersByTime(500)
+    fireKey('h')
+    expect(handlers.onGoHome).toHaveBeenCalledOnce()
+    expect(handlers.onGoTasks).not.toHaveBeenCalled()
+  })
+
+  it('g then t within 1.5s triggers onGoTasks', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    vi.advanceTimersByTime(500)
+    fireKey('t')
+    expect(handlers.onGoTasks).toHaveBeenCalledOnce()
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+  })
+
+  it('g then h does not also trigger onGoTasks', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    fireKey('h')
+    expect(handlers.onGoTasks).not.toHaveBeenCalled()
+  })
+
+  it('g then t does not also trigger onGoHome', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    fireKey('t')
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+  })
+
+  it('chord times out after 1.5s and subsequent h does not trigger onGoHome', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    vi.advanceTimersByTime(1500)
+    fireKey('h')
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+  })
+
+  it('g then unknown key silently cancels the chord', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    fireKey('x')
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+    expect(handlers.onGoTasks).not.toHaveBeenCalled()
+  })
+
+  it('subsequent single-key shortcuts work after a cancelled chord', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    fireKey('x') // cancels chord
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
+  })
+
+  it('chord fires even while an input is focused (second key)', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('g')
+    input.focus()
+    fireKey('h')
+    expect(handlers.onGoHome).toHaveBeenCalledOnce()
+  })
+
+  it('removes the keydown listener on unmount', () => {
+    const { unmount } = renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    unmount()
+    fireKey('?')
+    expect(handlers.onShowHelp).not.toHaveBeenCalled()
+  })
+
+  it('does not fire any shortcut when disabled is true', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers, { disabled: true }))
+    fireKey('?')
+    fireKey('g')
+    fireKey('h')
+    expect(handlers.onShowHelp).not.toHaveBeenCalled()
+    expect(handlers.onGoHome).not.toHaveBeenCalled()
+    expect(handlers.onGoTasks).not.toHaveBeenCalled()
+  })
+
+  it('fires shortcuts normally when disabled is false', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers, { disabled: false }))
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
+  })
+
+  it('fires shortcuts normally when disabled option is omitted', () => {
+    renderHook(() => useGlobalKeyboardShortcuts(handlers))
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
+  })
+
+  it('respects disabled toggling without remounting', () => {
+    let disabled = false
+    const { rerender } = renderHook(() =>
+      useGlobalKeyboardShortcuts(handlers, { disabled }),
+    )
+
+    // Enabled — shortcut fires
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
+
+    // Disable and rerender
+    disabled = true
+    rerender()
+    fireKey('?')
+    expect(handlers.onShowHelp).toHaveBeenCalledOnce() // still only one call
+  })
+})

--- a/TaskFlow.Web/src/hooks/useGlobalKeyboardShortcuts.ts
+++ b/TaskFlow.Web/src/hooks/useGlobalKeyboardShortcuts.ts
@@ -1,0 +1,87 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { isInputFocused } from '@/lib/keyboard-utils'
+
+export interface GlobalShortcutHandlers {
+  onGoHome: () => void
+  onGoTasks: () => void
+  onShowHelp: () => void
+}
+
+/**
+ * Global keyboard shortcut handler for navigation shortcuts available on every page.
+ *
+ * Single-key shortcuts fire only when no text input is focused (Gmail convention).
+ * Two-key chords (g → h, g → t) use a 1.5s window after pressing g.
+ */
+export function useGlobalKeyboardShortcuts(
+  handlers: GlobalShortcutHandlers,
+  options?: { disabled?: boolean },
+): void {
+  // Use a ref so the effect closure always sees the latest handlers
+  const handlersRef = useRef(handlers)
+  useLayoutEffect(() => {
+    handlersRef.current = handlers
+  })
+
+  const optionsRef = useRef(options)
+  useLayoutEffect(() => {
+    optionsRef.current = options
+  })
+
+  // Track pending chord: null = no chord, 'g' = waiting for second key
+  const pendingChordRef = useRef<string | null>(null)
+  const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    function clearChord() {
+      pendingChordRef.current = null
+      if (chordTimerRef.current !== null) {
+        clearTimeout(chordTimerRef.current)
+        chordTimerRef.current = null
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (optionsRef.current?.disabled) return
+
+      // Never fire shortcuts from modifier combos (Ctrl/Alt/Meta)
+      if (e.ctrlKey || e.altKey || e.metaKey) return
+
+      // If a chord is pending, handle the second key regardless of input focus
+      if (pendingChordRef.current === 'g') {
+        clearChord()
+        if (e.key === 'h') {
+          e.preventDefault()
+          handlersRef.current.onGoHome()
+        } else if (e.key === 't') {
+          e.preventDefault()
+          handlersRef.current.onGoTasks()
+        }
+        // Any other key silently cancels the chord
+        return
+      }
+
+      // Single-key shortcuts only fire when no text field is active
+      if (isInputFocused()) return
+
+      switch (e.key) {
+        case '?':
+          e.preventDefault()
+          handlersRef.current.onShowHelp()
+          break
+        case 'g':
+          // Start chord; wait up to 1.5s for the second key
+          e.preventDefault()
+          pendingChordRef.current = 'g'
+          chordTimerRef.current = setTimeout(clearChord, 1500)
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      if (chordTimerRef.current !== null) clearTimeout(chordTimerRef.current)
+    }
+  }, []) // stable — handlers and options accessed via refs
+}

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
@@ -10,9 +10,6 @@ function makeHandlers(): JournalShortcutHandlers {
     onNewNote: vi.fn(),
     onPrevDay: vi.fn(),
     onNextDay: vi.fn(),
-    onGoHome: vi.fn(),
-    onGoTasks: vi.fn(),
-    onShowHelp: vi.fn(),
   }
 }
 
@@ -63,12 +60,6 @@ describe('useJournalKeyboardShortcuts', () => {
     expect(handlers.onNextDay).toHaveBeenCalledOnce()
   })
 
-  it('fires onShowHelp when ? is pressed', () => {
-    renderHook(() => useJournalKeyboardShortcuts(handlers))
-    fireKey('?')
-    expect(handlers.onShowHelp).toHaveBeenCalledOnce()
-  })
-
   it('does not fire shortcuts when an input is focused', () => {
     const input = document.createElement('input')
     document.body.appendChild(input)
@@ -80,14 +71,12 @@ describe('useJournalKeyboardShortcuts', () => {
     fireKey('n')
     fireKey('[')
     fireKey(']')
-    fireKey('?')
 
     expect(handlers.onNewTodo).not.toHaveBeenCalled()
     expect(handlers.onNewLog).not.toHaveBeenCalled()
     expect(handlers.onNewNote).not.toHaveBeenCalled()
     expect(handlers.onPrevDay).not.toHaveBeenCalled()
     expect(handlers.onNextDay).not.toHaveBeenCalled()
-    expect(handlers.onShowHelp).not.toHaveBeenCalled()
   })
 
   it('does not fire shortcuts when a textarea is focused', () => {
@@ -108,52 +97,15 @@ describe('useJournalKeyboardShortcuts', () => {
     expect(handlers.onNewTodo).not.toHaveBeenCalled()
   })
 
-  it('g then h within 1.5s triggers onGoHome', () => {
+  it('does not start a chord when g is pressed', () => {
     renderHook(() => useJournalKeyboardShortcuts(handlers))
     fireKey('g')
-    vi.advanceTimersByTime(500)
     fireKey('h')
-    expect(handlers.onGoHome).toHaveBeenCalledOnce()
-    expect(handlers.onGoTasks).not.toHaveBeenCalled()
-  })
-
-  it('g then t within 1.5s triggers onGoTasks', () => {
-    renderHook(() => useJournalKeyboardShortcuts(handlers))
-    fireKey('g')
-    vi.advanceTimersByTime(500)
-    fireKey('t')
-    expect(handlers.onGoTasks).toHaveBeenCalledOnce()
-    expect(handlers.onGoHome).not.toHaveBeenCalled()
-  })
-
-  it('chord times out after 1.5s and subsequent h does not trigger onGoHome', () => {
-    renderHook(() => useJournalKeyboardShortcuts(handlers))
-    fireKey('g')
-    vi.advanceTimersByTime(1500)
-    fireKey('h')
-    expect(handlers.onGoHome).not.toHaveBeenCalled()
-  })
-
-  it('g then unknown key silently cancels the chord', () => {
-    renderHook(() => useJournalKeyboardShortcuts(handlers))
-    fireKey('g')
-    fireKey('x')
-    expect(handlers.onGoHome).not.toHaveBeenCalled()
-    expect(handlers.onGoTasks).not.toHaveBeenCalled()
-    // Subsequent shortcuts should still work
-    fireKey('t')
-    expect(handlers.onNewTodo).toHaveBeenCalledOnce()
-  })
-
-  it('chord fires even while an input is focused (second key)', () => {
-    const input = document.createElement('input')
-    document.body.appendChild(input)
-
-    renderHook(() => useJournalKeyboardShortcuts(handlers))
-    fireKey('g')
-    input.focus()
-    fireKey('h')
-    expect(handlers.onGoHome).toHaveBeenCalledOnce()
+    expect(handlers.onNewTodo).not.toHaveBeenCalled()
+    expect(handlers.onNewLog).not.toHaveBeenCalled()
+    expect(handlers.onNewNote).not.toHaveBeenCalled()
+    expect(handlers.onPrevDay).not.toHaveBeenCalled()
+    expect(handlers.onNextDay).not.toHaveBeenCalled()
   })
 
   it('removes the keydown listener on unmount', () => {

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef } from 'react'
+import { isInputFocused } from '@/lib/keyboard-utils'
 
 export interface JournalShortcutHandlers {
   onNewTodo: () => void
@@ -6,23 +7,13 @@ export interface JournalShortcutHandlers {
   onNewNote: () => void
   onPrevDay: () => void
   onNextDay: () => void
-  onGoHome: () => void
-  onGoTasks: () => void
-  onShowHelp: () => void
-}
-
-function isInputFocused(): boolean {
-  const el = document.activeElement
-  if (!el) return false
-  const tag = el.tagName
-  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el as HTMLElement).isContentEditable
 }
 
 /**
- * Global keyboard shortcut handler for the journal page.
+ * Keyboard shortcut handler for journal-specific actions.
  *
  * Single-key shortcuts fire only when no text input is focused (Gmail convention).
- * Two-key chords (g → h, g → t) use a 1.5s window after pressing g.
+ * Navigation shortcuts (g→h, g→t, ?) are handled globally by useGlobalKeyboardShortcuts.
  */
 export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
   // Use a ref so the effect closure always sees the latest handlers
@@ -31,45 +22,15 @@ export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
     handlersRef.current = handlers
   })
 
-  // Track pending chord: null = no chord, 'g' = waiting for second key
-  const pendingChordRef = useRef<string | null>(null)
-  const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
   useEffect(() => {
-    function clearChord() {
-      pendingChordRef.current = null
-      if (chordTimerRef.current !== null) {
-        clearTimeout(chordTimerRef.current)
-        chordTimerRef.current = null
-      }
-    }
-
     function handleKeyDown(e: KeyboardEvent) {
       // Never fire shortcuts from modifier combos (Ctrl/Alt/Meta)
       if (e.ctrlKey || e.altKey || e.metaKey) return
-
-      // If a chord is pending, handle the second key regardless of input focus
-      if (pendingChordRef.current === 'g') {
-        clearChord()
-        if (e.key === 'h') {
-          e.preventDefault()
-          handlersRef.current.onGoHome()
-        } else if (e.key === 't') {
-          e.preventDefault()
-          handlersRef.current.onGoTasks()
-        }
-        // Any other key silently cancels the chord
-        return
-      }
 
       // Single-key shortcuts only fire when no text field is active
       if (isInputFocused()) return
 
       switch (e.key) {
-        case '?':
-          e.preventDefault()
-          handlersRef.current.onShowHelp()
-          break
         case 't':
           e.preventDefault()
           handlersRef.current.onNewTodo()
@@ -90,19 +51,12 @@ export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
           e.preventDefault()
           handlersRef.current.onNextDay()
           break
-        case 'g':
-          // Start chord; wait up to 1.5s for the second key
-          e.preventDefault()
-          pendingChordRef.current = 'g'
-          chordTimerRef.current = setTimeout(clearChord, 1500)
-          break
       }
     }
 
     document.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
-      if (chordTimerRef.current !== null) clearTimeout(chordTimerRef.current)
     }
   }, []) // stable — handlers accessed via ref
 }

--- a/TaskFlow.Web/src/journal.css
+++ b/TaskFlow.Web/src/journal.css
@@ -423,7 +423,7 @@
   color: var(--muted);
 }
 
-.journal-page .j-modal-close {
+.j-modal-close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -434,7 +434,7 @@
   padding: 6px 10px;
   font-size: 13px;
 }
-.journal-page .j-modal-close:hover { background: var(--hover-soft); }
+.j-modal-close:hover { background: var(--hover-soft); }
 
 /* ─── Keyboard shortcuts modal ─────────────────────────────────────────────── */
 

--- a/TaskFlow.Web/src/lib/keyboard-utils.test.ts
+++ b/TaskFlow.Web/src/lib/keyboard-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isInputFocused } from './keyboard-utils'
+
+describe('isInputFocused', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns false when no element is focused', () => {
+    expect(isInputFocused()).toBe(false)
+  })
+
+  it('returns true when an input is the active element', () => {
+    const el = document.createElement('input')
+    document.body.appendChild(el)
+    el.focus()
+    expect(isInputFocused()).toBe(true)
+  })
+
+  it('returns true when a textarea is the active element', () => {
+    const el = document.createElement('textarea')
+    document.body.appendChild(el)
+    el.focus()
+    expect(isInputFocused()).toBe(true)
+  })
+
+  it('returns true when a select is the active element', () => {
+    const el = document.createElement('select')
+    document.body.appendChild(el)
+    el.focus()
+    expect(isInputFocused()).toBe(true)
+  })
+
+  it('returns true when a contentEditable element is the active element', () => {
+    // jsdom does not implement isContentEditable, so we stub activeElement directly
+    const el = document.createElement('div')
+    Object.defineProperty(el, 'isContentEditable', { value: true, configurable: true })
+    const spy = vi.spyOn(document, 'activeElement', 'get').mockReturnValue(el)
+    expect(isInputFocused()).toBe(true)
+    spy.mockRestore()
+  })
+
+  it('returns false when a non-input element (button) is the active element', () => {
+    const el = document.createElement('button')
+    document.body.appendChild(el)
+    el.focus()
+    expect(isInputFocused()).toBe(false)
+  })
+
+  it('returns false when a plain div is the active element', () => {
+    const el = document.createElement('div')
+    el.setAttribute('tabindex', '0')
+    document.body.appendChild(el)
+    el.focus()
+    expect(isInputFocused()).toBe(false)
+  })
+})

--- a/TaskFlow.Web/src/lib/keyboard-utils.ts
+++ b/TaskFlow.Web/src/lib/keyboard-utils.ts
@@ -1,0 +1,11 @@
+export function isInputFocused(): boolean {
+  const el = document.activeElement
+  if (!el) return false
+  const tag = el.tagName
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    !!(el as HTMLElement).isContentEditable
+  )
+}

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useRef } from 'react'
 import { useParams, useOutletContext, useNavigate } from 'react-router-dom'
 import { useEnsureJournalEntry } from '@/hooks/useJournal'
 import { urlDateToISO, todayISO, isValidISODate, addDays, isoToUrlDate } from '@/lib/journal-utils'
@@ -10,7 +10,6 @@ import { DailyLogSection } from '@/components/journal/DailyLogSection'
 import type { DailyLogSectionHandle } from '@/components/journal/DailyLogSection'
 import { NotesSection } from '@/components/journal/NotesSection'
 import type { NotesSectionHandle } from '@/components/journal/NotesSection'
-import { KeyboardShortcutsModal } from '@/components/journal/KeyboardShortcutsModal'
 import { useJournalKeyboardShortcuts } from '@/hooks/useJournalKeyboardShortcuts'
 import type { AppContext } from '@/components/Layout'
 import '@/journal.css'
@@ -31,8 +30,6 @@ export function JournalPage() {
 
   const { isDark, headerStyle, todoSort, projectStart } = useOutletContext<AppContext>()
 
-  const [showShortcuts, setShowShortcuts] = useState(false)
-
   const todosSectionRef = useRef<TodosSectionHandle>(null)
   const logSectionRef = useRef<DailyLogSectionHandle>(null)
   const notesSectionRef = useRef<NotesSectionHandle>(null)
@@ -43,9 +40,6 @@ export function JournalPage() {
     onNewNote: () => notesSectionRef.current?.focusNewNote(),
     onPrevDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, -1))}`),
     onNextDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, 1))}`),
-    onGoHome: () => navigate(`/journal/${isoToUrlDate(todayISO())}`),
-    onGoTasks: () => navigate('/tasks'),
-    onShowHelp: () => setShowShortcuts(prev => !prev),
   })
 
   return (
@@ -90,9 +84,6 @@ export function JournalPage() {
         </article>
       </div>
 
-      {showShortcuts && (
-        <KeyboardShortcutsModal onClose={() => setShowShortcuts(false)} />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Navigation shortcuts (`?`, `g→h`, `g→t`) now work on every page (Tasks, Task Detail, Journal) — previously they were silently ignored outside the journal
- New `useGlobalKeyboardShortcuts` hook mounted in `Layout` handles cross-page shortcuts; journal-only shortcuts (`t`, `l`, `n`, `[`, `]`) remain in `useJournalKeyboardShortcuts`
- `KeyboardShortcutsModal` relocated from `journal/` to `components/` so it can be rendered by Layout; shortcuts grouped into four sections: Navigation (all pages), Journal — Day Navigation, Journal — Actions, Inputs
- Shared `isInputFocused()` utility extracted to `src/lib/keyboard-utils.ts`
- Global shortcuts are suppressed while the help modal is open (prevents the hook from immediately re-opening it) and while the settings drawer is open

## Test plan

- [ ] Navigate to `/tasks`, press `?` — help modal opens with four grouped sections
- [ ] Press `?` again — modal closes
- [ ] Press `Escape` — modal closes
- [ ] Press `g` then `h` from the Tasks page — navigates to today's journal
- [ ] Press `g` then `t` from the Journal page — navigates to `/tasks`
- [ ] Press `[` and `]` on the Journal page — day navigation works as before
- [ ] Open settings drawer, press `?` — no modal (suppressed)
- [ ] Repeat smoke test from `/tasks/:id`
- [ ] 97 tests pass, 0 TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)