### PR TITLE
feat: add j shortcut to jump to today's journal entry

### DIFF
--- a/TaskFlow.Web/src/components/KeyboardShortcutsModal.test.tsx
+++ b/TaskFlow.Web/src/components/KeyboardShortcutsModal.test.tsx
@@ -13,9 +13,9 @@ describe('KeyboardShortcutsModal', () => {
     document.body.style.overflow = ''
   })
 
-  it('renders the Navigation (all pages) group with g→h, g→t, and ? shortcuts', () => {
+  it('renders the Navigation — All Pages group with g→h, g→t, and ? shortcuts', () => {
     renderModal()
-    expect(screen.getByText('Navigation (all pages)')).toBeInTheDocument()
+    expect(screen.getByText('Navigation — All Pages')).toBeInTheDocument()
     expect(screen.getByText('Go to today (home)')).toBeInTheDocument()
     expect(screen.getByText('Go to tasks page')).toBeInTheDocument()
     expect(screen.getByText('Show / hide this help')).toBeInTheDocument()
@@ -28,7 +28,7 @@ describe('KeyboardShortcutsModal', () => {
     expect(screen.getByText('Next day')).toBeInTheDocument()
   })
 
-  it('renders the Journal — Actions group with t, l, and n shortcuts', () => {
+  it('renders the Journal — Actions group with t, l, n, and j shortcuts', () => {
     renderModal()
     expect(screen.getByText('Journal — Actions')).toBeInTheDocument()
     expect(screen.getByText('New todo')).toBeInTheDocument()
@@ -36,9 +36,19 @@ describe('KeyboardShortcutsModal', () => {
     expect(screen.getByText('Focus notes')).toBeInTheDocument()
   })
 
-  it('renders the Inputs group with Esc shortcut', () => {
+  it('renders the j shortcut in the Journal — Actions group', () => {
     renderModal()
-    expect(screen.getByText('Inputs')).toBeInTheDocument()
+    expect(screen.getByText('Go to today')).toBeInTheDocument()
+    const journalActionsGroup = screen.getByText('Journal — Actions').closest('.kb-group')
+    expect(journalActionsGroup).not.toBeNull()
+    const kbds = journalActionsGroup!.querySelectorAll('kbd')
+    const jKbd = Array.from(kbds).find(kbd => kbd.textContent === 'j')
+    expect(jKbd).toBeDefined()
+  })
+
+  it('renders the Inputs — All Pages group with Esc shortcut', () => {
+    renderModal()
+    expect(screen.getByText('Inputs — All Pages')).toBeInTheDocument()
     expect(screen.getByText('Cancel / deselect focused field')).toBeInTheDocument()
   })
 

--- a/TaskFlow.Web/src/components/KeyboardShortcutsModal.tsx
+++ b/TaskFlow.Web/src/components/KeyboardShortcutsModal.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 const SHORTCUTS = [
   {
-    group: 'Navigation (all pages)',
+    group: 'Navigation — All Pages',
     items: [
       { keys: ['g', 'h'], description: 'Go to today (home)' },
       { keys: ['g', 't'], description: 'Go to tasks page' },
@@ -26,10 +26,11 @@ const SHORTCUTS = [
       { keys: ['t'], description: 'New todo' },
       { keys: ['l'], description: 'New log entry' },
       { keys: ['n'], description: 'Focus notes' },
+      { keys: ['j'], description: 'Go to today' },
     ],
   },
   {
-    group: 'Inputs',
+    group: 'Inputs — All Pages',
     items: [
       { keys: ['Esc'], description: 'Cancel / deselect focused field' },
     ],

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.test.ts
@@ -10,6 +10,7 @@ function makeHandlers(): JournalShortcutHandlers {
     onNewNote: vi.fn(),
     onPrevDay: vi.fn(),
     onNextDay: vi.fn(),
+    onJumpToToday: vi.fn(),
   }
 }
 
@@ -60,6 +61,12 @@ describe('useJournalKeyboardShortcuts', () => {
     expect(handlers.onNextDay).toHaveBeenCalledOnce()
   })
 
+  it('fires onJumpToToday when j is pressed with no input focused', () => {
+    renderHook(() => useJournalKeyboardShortcuts(handlers))
+    fireKey('j')
+    expect(handlers.onJumpToToday).toHaveBeenCalledOnce()
+  })
+
   it('does not fire shortcuts when an input is focused', () => {
     const input = document.createElement('input')
     document.body.appendChild(input)
@@ -71,12 +78,14 @@ describe('useJournalKeyboardShortcuts', () => {
     fireKey('n')
     fireKey('[')
     fireKey(']')
+    fireKey('j')
 
     expect(handlers.onNewTodo).not.toHaveBeenCalled()
     expect(handlers.onNewLog).not.toHaveBeenCalled()
     expect(handlers.onNewNote).not.toHaveBeenCalled()
     expect(handlers.onPrevDay).not.toHaveBeenCalled()
     expect(handlers.onNextDay).not.toHaveBeenCalled()
+    expect(handlers.onJumpToToday).not.toHaveBeenCalled()
   })
 
   it('does not fire shortcuts when a textarea is focused', () => {
@@ -94,7 +103,11 @@ describe('useJournalKeyboardShortcuts', () => {
     fireKey('t', { ctrlKey: true })
     fireKey('t', { altKey: true })
     fireKey('t', { metaKey: true })
+    fireKey('j', { ctrlKey: true })
+    fireKey('j', { altKey: true })
+    fireKey('j', { metaKey: true })
     expect(handlers.onNewTodo).not.toHaveBeenCalled()
+    expect(handlers.onJumpToToday).not.toHaveBeenCalled()
   })
 
   it('does not start a chord when g is pressed', () => {
@@ -114,4 +127,5 @@ describe('useJournalKeyboardShortcuts', () => {
     fireKey('t')
     expect(handlers.onNewTodo).not.toHaveBeenCalled()
   })
+
 })

--- a/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
+++ b/TaskFlow.Web/src/hooks/useJournalKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ export interface JournalShortcutHandlers {
   onNewNote: () => void
   onPrevDay: () => void
   onNextDay: () => void
+  onJumpToToday: () => void
 }
 
 /**
@@ -50,6 +51,10 @@ export function useJournalKeyboardShortcuts(handlers: JournalShortcutHandlers) {
         case ']':
           e.preventDefault()
           handlersRef.current.onNextDay()
+          break
+        case 'j':
+          e.preventDefault()
+          handlersRef.current.onJumpToToday()
           break
       }
     }

--- a/TaskFlow.Web/src/pages/JournalPage.tsx
+++ b/TaskFlow.Web/src/pages/JournalPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef } from 'react'
 import { useParams, useOutletContext, useNavigate } from 'react-router-dom'
 import { useEnsureJournalEntry } from '@/hooks/useJournal'
-import { urlDateToISO, todayISO, isValidISODate, addDays, isoToUrlDate } from '@/lib/journal-utils'
+import { urlDateToISO, todayISO, isValidISODate, addDays, isoToUrlDate, todayUrlDate } from '@/lib/journal-utils'
 import { DateNav } from '@/components/journal/DateNav'
 import { JournalHeader } from '@/components/journal/JournalHeader'
 import { TodosSection } from '@/components/journal/TodosSection'
@@ -40,6 +40,7 @@ export function JournalPage() {
     onNewNote: () => notesSectionRef.current?.focusNewNote(),
     onPrevDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, -1))}`),
     onNextDay: () => navigate(`/journal/${isoToUrlDate(addDays(effectiveDate, 1))}`),
+    onJumpToToday: () => { if (effectiveDate !== todayISO()) navigate(`/journal/${todayUrlDate()}`) },
   })
 
   return (


### PR DESCRIPTION
## Summary

- Adds `j` as a journal-page-only keyboard shortcut that navigates to today's journal entry; silently does nothing when already on today
- Renames shortcut dialog section labels to a consistent em-dash pattern (`Navigation — All Pages`, `Inputs — All Pages`) so global vs. journal-only scope is visually unambiguous
- Adds `j — Go to today` entry under the **Journal — Actions** group in the shortcuts modal

## Test plan

- [ ] On a past/future journal date, press `j` — should navigate to today's entry
- [ ] On today's journal entry, press `j` — should do nothing (no navigation)
- [ ] Press `j` while an input/textarea is focused — should do nothing
- [ ] Press `Ctrl+j`, `Alt+j`, `Meta+j` — should do nothing
- [ ] Open the `?` shortcuts modal — confirm all four group labels and the new `j` entry display correctly
- [ ] CI: 99 tests passing, clean `tsc --noEmit`

## Known gap

`JournalPage.tsx` has no test file — the `effectiveDate !== todayISO()` guard (no-op when already on today) is untested by automated tests. Frontend integration tests for `JournalPage` will be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)