### PR TITLE
fix: correct timezone offset sign for journal task creation

### DIFF
--- a/TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs
+++ b/TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs
@@ -234,6 +234,38 @@ public class TaskItemsControllerV1Tests
     }
 
     [Fact]
+    public async Task Create_ShouldForwardTimezoneOffsetToAddTodoAsync_WhenJournalDateIsToday()
+    {
+        // User in UTC-5 (timezoneOffsetMinutes = -300). Their "today" = utcNow - 5h.
+        // Before the fix, AddTodoAsync received no timezone offset and saw today as UTC today,
+        // causing it to silently return PastDayNotAllowed and drop the journal link.
+        const int offsetMinutes = -300;
+        var userToday = DateOnly.FromDateTime(DateTime.UtcNow.AddMinutes(offsetMinutes));
+        var createDto = new CreateTaskItemDto
+        {
+            Title = "Task for today",
+            JournalDate = userToday,
+            TimezoneOffsetMinutes = offsetMinutes
+        };
+
+        var createdTask = new TaskItem { Id = 55, Title = "Task for today", Status = Status.Todo };
+        var entry = new JournalEntry { Id = 8, Date = userToday, Title = "Journal" };
+
+        _mockValidator.Setup(v => v.ValidateAsync(It.IsAny<TaskItem>(), default))
+            .ReturnsAsync(new ValidationResult());
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<TaskItem>())).ReturnsAsync(createdTask);
+        _mockRepo.Setup(r => r.GetByIdAsync(55)).ReturnsAsync(createdTask);
+        _mockJournalRepo.Setup(r => r.GetByDateAsync(userToday)).ReturnsAsync(entry);
+        _mockJournalRepo.Setup(r => r.AddTodoAsync(entry.Id, createdTask.Id, offsetMinutes))
+            .ReturnsAsync(AddTodoResult.Success);
+
+        var result = await _controller.Create(createDto);
+
+        result.Result.Should().BeOfType<CreatedAtRouteResult>();
+        _mockJournalRepo.Verify(r => r.AddTodoAsync(entry.Id, createdTask.Id, offsetMinutes), Times.Once);
+    }
+
+    [Fact]
     public async Task Create_ShouldReturnUnprocessableEntity_WhenParentWouldExceedOneLevelDepth()
     {
         var createDto = new CreateTaskItemDto

--- a/TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs
+++ b/TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs
@@ -182,6 +182,27 @@ public class TaskItemsControllerV1Tests
     }
 
     [Fact]
+    public async Task Create_ShouldReturnUnprocessableEntity_WhenJournalDateIsYesterdayInUserTimezone()
+    {
+        // timezoneOffsetMinutes uses UTC-offset convention (negative = west of UTC)
+        // User's "today" = utcNow + offset; a negative offset shifts the date earlier
+        const int offsetMinutes = -300; // UTC-5 (e.g. CDT)
+        var userYesterday = DateOnly.FromDateTime(DateTime.UtcNow.AddMinutes(offsetMinutes).AddDays(-1));
+
+        var createDto = new CreateTaskItemDto
+        {
+            Title = "Task",
+            JournalDate = userYesterday,
+            TimezoneOffsetMinutes = offsetMinutes
+        };
+
+        var result = await _controller.Create(createDto);
+
+        result.Result.Should().BeOfType<UnprocessableEntityObjectResult>();
+        _mockRepo.Verify(r => r.AddAsync(It.IsAny<TaskItem>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Create_ShouldAssignToJournalDate_WhenJournalDateIsProvided()
     {
         var targetDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));

--- a/TaskFlow.Api/Controllers/V1/JournalTodosController.cs
+++ b/TaskFlow.Api/Controllers/V1/JournalTodosController.cs
@@ -53,7 +53,7 @@ public class JournalTodosController(
             return BadRequest(validationResult.Errors);
         }
 
-        var result = await _journalRepo.AddTodoAsync(entryId, dto.TaskItemId);
+        var result = await _journalRepo.AddTodoAsync(entryId, dto.TaskItemId, dto.TimezoneOffsetMinutes);
         return result switch
         {
             AddTodoResult.EntryNotFound => NotFound(),

--- a/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
+++ b/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
@@ -148,7 +148,7 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
 
         if (createDto.JournalDate.HasValue)
         {
-            await AssignToJournalDateAsync(createdItem.Id, createDto.JournalDate.Value);
+            await AssignToJournalDateAsync(createdItem.Id, createDto.JournalDate.Value, createDto.TimezoneOffsetMinutes);
         }
 
         var refreshed = await _repo.GetByIdAsync(createdItem.Id) ?? createdItem;
@@ -237,7 +237,10 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
         if (wasCompleted && !nowCompleted)
         {
             var assignedDate = await _repo.GetAssignedJournalDateAsync(id);
-            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            var userNow = updateDto.TimezoneOffsetMinutes.HasValue
+                ? DateTime.UtcNow.AddMinutes(updateDto.TimezoneOffsetMinutes.Value)
+                : DateTime.UtcNow;
+            var today = DateOnly.FromDateTime(userNow);
             if (assignedDate.HasValue && assignedDate.Value < today)
             {
                 return UnprocessableEntity(new
@@ -391,7 +394,7 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
         }
     }
 
-    private async Task AssignToJournalDateAsync(int taskId, DateOnly journalDate)
+    private async Task AssignToJournalDateAsync(int taskId, DateOnly journalDate, int? timezoneOffsetMinutes = null)
     {
         if (_journalRepo is null)
         {
@@ -405,7 +408,7 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
                 Date = journalDate,
             });
 
-        await _journalRepo.AddTodoAsync(entry.Id, taskId);
+        await _journalRepo.AddTodoAsync(entry.Id, taskId, timezoneOffsetMinutes);
     }
 
     private async Task<TaskItemResponseDto> MapTaskItemResponseAsync(TaskItem item, IReadOnlyDictionary<int, int>? childCounts = null)

--- a/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
+++ b/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
@@ -89,7 +89,7 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
             DateTime userNow = utcNow;
             if (createDto.TimezoneOffsetMinutes.HasValue)
             {
-                userNow = utcNow.AddMinutes(-createDto.TimezoneOffsetMinutes.Value);
+                userNow = utcNow.AddMinutes(createDto.TimezoneOffsetMinutes.Value);
             }
             var today = DateOnly.FromDateTime(userNow);
             if (createDto.JournalDate.Value < today)

--- a/TaskFlow.Api/DTOs/AddJournalTodoDto.cs
+++ b/TaskFlow.Api/DTOs/AddJournalTodoDto.cs
@@ -3,4 +3,5 @@ namespace TaskFlow.Api.DTOs;
 public class AddJournalTodoDto
 {
     public int TaskItemId { get; set; }
+    public int? TimezoneOffsetMinutes { get; set; }
 }

--- a/TaskFlow.Api/DTOs/UpdateTaskItemDto.cs
+++ b/TaskFlow.Api/DTOs/UpdateTaskItemDto.cs
@@ -12,4 +12,5 @@ public class UpdateTaskItemDto
     public DateTime? DueDate { get; set; }
     public int? ParentTaskItemId { get; set; }
     public bool AutoCompleteParentWhenChildrenDone { get; set; }
+    public int? TimezoneOffsetMinutes { get; set; }
 }

--- a/TaskFlow.Api/Repositories/IJournalEntryRepository.cs
+++ b/TaskFlow.Api/Repositories/IJournalEntryRepository.cs
@@ -12,6 +12,6 @@ public interface IJournalEntryRepository
     Task DeleteAsync(int id);
     Task<IEnumerable<TaskItem>> GetTodosAsync(int entryId);
     Task<bool> TodoExistsAsync(int entryId, int taskItemId);
-    Task<AddTodoResult> AddTodoAsync(int entryId, int taskItemId);
+    Task<AddTodoResult> AddTodoAsync(int entryId, int taskItemId, int? timezoneOffsetMinutes = null);
     Task<bool> RemoveTodoAsync(int entryId, int taskItemId);
 }

--- a/TaskFlow.Api/Repositories/JournalEntryRepository.cs
+++ b/TaskFlow.Api/Repositories/JournalEntryRepository.cs
@@ -118,7 +118,7 @@ public class JournalEntryRepository(TaskDbContext context) : IJournalEntryReposi
         return entry?.Todos.Any(t => t.Id == taskItemId && t.CurrentJournalEntryId == entryId) ?? false;
     }
 
-    public async Task<AddTodoResult> AddTodoAsync(int entryId, int taskItemId)
+    public async Task<AddTodoResult> AddTodoAsync(int entryId, int taskItemId, int? timezoneOffsetMinutes = null)
     {
         var entry = await _context.JournalEntries
             .Include(e => e.Todos)
@@ -134,7 +134,10 @@ public class JournalEntryRepository(TaskDbContext context) : IJournalEntryReposi
             return AddTodoResult.TaskNotFound;
         }
 
-        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var userNow = timezoneOffsetMinutes.HasValue
+            ? DateTime.UtcNow.AddMinutes(timezoneOffsetMinutes.Value)
+            : DateTime.UtcNow;
+        var today = DateOnly.FromDateTime(userNow);
         if (entry.Date < today)
         {
             return AddTodoResult.PastDayNotAllowed;


### PR DESCRIPTION
## Summary
- Fixed sign error in `TaskItemsController.Create` where `timezoneOffsetMinutes` was negated before being added to UTC, inverting the user's timezone (UTC-5 was treated as UTC+5)
- The frontend sends UTC-offset convention (`-300` for UTC-5 / CDT); the backend now adds it directly with `AddMinutes(offset)` instead of `AddMinutes(-offset)`
- Added a regression test covering yesterday's date in the user's local timezone

## Impact
Any user west of UTC (negative UTC offset) would receive `TASK_CREATION_PAST_DAY_NOT_ALLOWED` when creating tasks after 19:00 UTC, even on the current day.

## Test Plan
- [x] All 222 backend tests pass
- [x] New test `Create_ShouldReturnUnprocessableEntity_WhenJournalDateIsYesterdayInUserTimezone` covers the UTC-offset convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)