### PR TITLE
chore: backend NuGet dependency audit — bump to 10.0.8, add Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- All packages in this group ship together on the same patch cadence.
+         Update this single property when a new .NET 10.x patch is released. -->
+    <MicrosoftPlatformVersion>10.0.8</MicrosoftPlatformVersion>
+  </PropertyGroup>
+</Project>

--- a/TaskFlow.Api.Tests/TaskFlow.Api.Tests.csproj
+++ b/TaskFlow.Api.Tests/TaskFlow.Api.Tests.csproj
@@ -11,18 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/TaskFlow.Api/Dockerfile
+++ b/TaskFlow.Api/Dockerfile
@@ -23,6 +23,7 @@ EXPOSE 8080
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
+COPY ["Directory.Build.props", "./"]
 COPY ["TaskFlow.Api/TaskFlow.Api.csproj", "TaskFlow.Api/"]
 RUN dotnet restore "TaskFlow.Api/TaskFlow.Api.csproj"
 

--- a/TaskFlow.Api/TaskFlow.Api.csproj
+++ b/TaskFlow.Api/TaskFlow.Api.csproj
@@ -27,15 +27,15 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftPlatformVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.13.22" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.14.14" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- Bumps all Microsoft .NET 10 platform packages from `10.0.5` to `10.0.8`, resolving CVE-2026-40372 (CVSS 9.1, ASP.NET Core Data Protection EoP) and four May 2026 Patch Tuesday CVEs (CVE-2026-42899, CVE-2026-32177, CVE-2026-35433, CVE-2026-32175)
- Introduces `Directory.Build.props` at the solution root with a single `MicrosoftPlatformVersion` property so all six Microsoft platform packages across both projects stay in sync with a single edit
- Bumps test tooling: `Microsoft.NET.Test.Sdk` → `18.6.0`, `coverlet.*` → `10.0.1` (adds explicit .NET 10 support), `FluentAssertions` → `8.10.0`
- Bumps `Scalar.AspNetCore` → `2.14.14` (minor release, no breaking changes)

## Packages updated

| Package | From | To | Location |
|---|---|---|---|
| `Microsoft.AspNetCore.OpenApi` | 10.0.5 | **10.0.8** | `Directory.Build.props` |
| `Microsoft.EntityFrameworkCore` | 10.0.5 | **10.0.8** | `Directory.Build.props` |
| `Microsoft.EntityFrameworkCore.Sqlite` | 10.0.5 | **10.0.8** | `Directory.Build.props` |
| `Microsoft.EntityFrameworkCore.Tools` | 10.0.5 | **10.0.8** | `Directory.Build.props` |
| `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore` | 10.0.5 | **10.0.8** | `Directory.Build.props` |
| `Microsoft.EntityFrameworkCore.InMemory` | 10.0.5 | **10.0.8** | `Directory.Build.props` |
| `Scalar.AspNetCore` | 2.13.22 | **2.14.14** | `TaskFlow.Api.csproj` |
| `Microsoft.NET.Test.Sdk` | 18.4.0 | **18.6.0** | `TaskFlow.Api.Tests.csproj` |
| `coverlet.collector` | 8.0.1 | **10.0.1** | `TaskFlow.Api.Tests.csproj` |
| `coverlet.msbuild` | 8.0.1 | **10.0.1** | `TaskFlow.Api.Tests.csproj` |
| `FluentAssertions` | 8.9.0 | **8.10.0** | `TaskFlow.Api.Tests.csproj` |

## Packages deliberately held

| Package | Version | Reason |
|---|---|---|
| `Asp.Versioning.Mvc` | 8.1.1 | v10.0.0 requires breaking changes to OpenAPI wiring; companion package `Asp.Versioning.OpenApi` is still prerelease (`10.0.0-rc.1`). No known CVEs at 8.1.1. |
| `Asp.Versioning.Mvc.ApiExplorer` | 8.1.1 | Same — must be updated atomically with `Asp.Versioning.Mvc`. |

A follow-up issue should be opened to track the Asp.Versioning v10 migration once `Asp.Versioning.OpenApi` reaches a stable release.

## Security notes

All five CVEs are in the ASP.NET Core / .NET runtime shared framework, not application-level NuGet packages. The Docker base image (`mcr.microsoft.com/dotnet/aspnet:10.0`) uses a floating tag — a `--no-cache` build was performed locally to force a fresh pull of the patched runtime. The Trivy scan in `security-scan.yml` will confirm the image is clean on this PR.

## Verification

- `dotnet list package --vulnerable` → zero findings (both projects)
- `dotnet build TaskFlow.sln --configuration Release` → 0 warnings, 0 errors
- `dotnet test TaskFlow.sln --configuration Release` → 223 passed, 0 failed
- `dotnet format TaskFlow.sln --verify-no-changes` → no drift

## Test plan

- [ ] CI passes (lint → build → test → smoke test)
- [ ] Trivy scan reports no CRITICAL/HIGH findings on the rebuilt image
- [ ] `dependency-review` GitHub Action reports no newly introduced vulnerable packages
- [ ] After merge, verify Portainer GitOps deploys successfully and `/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)