### PR TITLE
chore: improve explore-then-build pipeline and open-questions-gate skill

### DIFF
--- a/.claude/skills/explore-then-build/SKILL.md
+++ b/.claude/skills/explore-then-build/SKILL.md
@@ -179,7 +179,7 @@ Announce: "Step 5.5/8 — Verifying backend builds and tests pass before proceed
 Run the backend build:
 
 ```bash
-dotnet build TaskFlow.Api --no-incremental
+dotnet build
 ```
 
 If the build fails: stop the pipeline. Display the full build error output. Ask using `AskUserQuestion`:
@@ -199,7 +199,7 @@ If "Abort the pipeline": stop immediately.
 If the build succeeds, run the tests:
 
 ```bash
-dotnet test TaskFlow.Api.Tests --no-build
+dotnet test --no-build
 ```
 
 If tests fail: stop the pipeline, display the test failure output, and present the same three options above (substituting test failure output for build errors).

--- a/.claude/skills/explore-then-build/SKILL.md
+++ b/.claude/skills/explore-then-build/SKILL.md
@@ -13,38 +13,46 @@ Trigger when the user asks to build, implement, or ship a feature. Key phrases: 
 
 ---
 
-## Step 1 — Branch Check and Creation (Bash)
+## Step 1 — Branch Check, Disclosure, and Creation
 
-Announce: "Step 1/8 — Checking branch status and creating feature branch."
+Announce: "Step 1/8 — Checking branch status, disclosing pipeline cost, and creating feature branch."
 
-Run these commands:
+**Token cost disclosure:** Before running any git commands, display this notice and use `AskUserQuestion` to confirm:
+
+> This pipeline will run 4–5 agents in sequence (codebase-researcher → spec-writer → backend-builder → frontend-builder → implementation-validator), each with its own context window. Open questions at any stage add extra revision cycles. Total token usage is approximately 10–15× a standard chat. Each agent run is billed separately.
+
+- **Question:** "Ready to start the explore-then-build pipeline?"
+- **Options:**
+  - "Yes — start the pipeline"
+  - "No — cancel"
+
+If "No — cancel": stop immediately. Do not proceed to any further steps.
+
+**Branch handling:** Check the current branch. If already on a feature or bugfix branch, proceed. If on `main`, derive a branch name from the user's feature description — convert it to lowercase, replace spaces with hyphens, strip non-alphanumeric characters, and truncate to 40 characters. Prefix with `feature/`. Pass the derived name as a literal string to the git command (do not use a shell variable for the branch name):
 
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 echo "Current branch: $CURRENT_BRANCH"
-
-if [ "$CURRENT_BRANCH" = "main" ]; then
-  echo "You are on main. Creating a feature branch..."
-  # Generate branch name from feature description
-  # Use the user's feature description to create a kebab-case branch name
-  FEATURE_NAME=$(echo "$USER_FEATURE_DESCRIPTION" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 -]//g' | tr ' ' '-' | cut -c1-40)
-  BRANCH_NAME="feature/$FEATURE_NAME"
-  
-  git checkout -b "$BRANCH_NAME"
-  echo "✓ Created and switched to branch: $BRANCH_NAME"
-else
-  echo "✓ Already on feature branch: $CURRENT_BRANCH"
-  echo "Proceeding with implementation..."
-fi
 ```
 
-If the branch creation fails, stop and ask the user to manually create a branch or stash uncommitted changes.
+If already on a feature branch, announce "Already on feature branch: [branch name]. Proceeding." and skip the checkout.
+
+If on `main`, run the checkout with the literal branch name derived above (substitute the actual name in place of the placeholder — do not use `$VARIABLE` syntax):
+
+```bash
+git checkout -b "feature/the-actual-derived-name-here"
+echo "✓ Created and switched to branch: feature/the-actual-derived-name-here"
+```
+
+If branch creation fails (non-zero exit), stop and ask the user to manually create a branch or stash uncommitted changes before retrying.
 
 ---
 
 ## Step 2 — Map the Codebase (codebase-researcher)
 
 Announce: "Step 2/8 — Mapping the codebase with codebase-researcher."
+
+Use `model: "sonnet"` for this agent. In the agent prompt, include: "Read `CLAUDE.md` at the project root before beginning — it documents the architecture, naming conventions, safe change rules, and testing requirements for this codebase."
 
 Launch the `codebase-researcher` agent with the user's feature description as the question. Ask it to identify:
 - Relevant files grouped by role (backend and frontend separately)
@@ -68,6 +76,8 @@ Do not proceed to Step 3 until the gate exits (either approved or no open questi
 
 Announce: "Step 3/8 — Writing the technical spec with spec-writer."
 
+Use `model: "opus"` for this agent — the spec-writer's output gates the entire implementation, so use the most capable model. In the agent prompt, include: "Read `CLAUDE.md` at the project root before beginning."
+
 Launch the `spec-writer` agent. Pass it:
 - The user's original feature description
 - A summary of the codebase-researcher findings (relevant files, patterns, similar features, risks) — use the finalized output from Step 2 (post-gate, if the gate ran)
@@ -81,6 +91,8 @@ Wait for the agent to return the full Technical Brief before proceeding.
 - Output label: `Technical Brief`
 
 Do not proceed to Step 4 until the gate exits. Present the finalized Technical Brief (post-gate) to the user for the approval gate below.
+
+**Save spec checkpoint:** Write the finalized Technical Brief to `docs/superpowers/pipeline-checkpoints/[branch-name]-spec.md`. Replace `[branch-name]` with the actual branch name. This allows the pipeline to be resumed from Step 5 if the session is interrupted.
 
 ---
 
@@ -104,6 +116,8 @@ Use `AskUserQuestion` with three options: "Approved", "Changes needed", "Rejecte
 
 Announce: "Step 5/8 — Implementing the backend with backend-builder."
 
+Use `model: "sonnet"` for this agent. In the agent prompt, include: "Read `CLAUDE.md` at the project root before beginning. Pay particular attention to the Coding Conventions, Architecture, and Testing sections — all generated code must follow these patterns exactly."
+
 Launch the `backend-builder` agent. Pass it:
 - The approved Technical Brief (full text)
 - The codebase-researcher findings (relevant backend file paths, patterns, similar examples)
@@ -118,15 +132,98 @@ Wait for the agent to complete and return a summary of what was built, including
 
 Do not proceed to Step 6 until the gate exits.
 
+**Record the backend-builder agent ID** returned at the end of the agent result (format: `agentId: <id>`). Store it as `BACKEND_AGENT_ID`. This ID is required for the Step 7 fix loop.
+
+**Review and commit the backend implementation:**
+
+Run the following to show the user what the agent changed:
+
+```bash
+git add -A
+git diff --staged --stat
+git diff --staged
+```
+
+Present the diff output to the user, then ask using `AskUserQuestion`:
+
+- **Question:** "Review the backend changes above. Ready to commit?"
+- **Options:**
+  - "Commit these changes"
+  - "I need to make adjustments first — hold the pipeline"
+
+If "I need to make adjustments first": pause. Do not commit. Wait for the user to indicate they are done with their adjustments, then re-run `git diff --staged` and re-ask.
+
+If "Commit these changes":
+
+```bash
+git commit -m "feat: implement backend for [feature name]"
+```
+
+Announce the commit hash. If `git diff --staged` showed nothing (the agent committed its own changes), announce "Backend agent committed its own changes — no additional commit needed." and continue.
+
+**Save backend checkpoint:** Append to `docs/superpowers/pipeline-checkpoints/[branch-name]-progress.md`:
+
+```
+Stage: backend-complete
+Backend agent ID: [BACKEND_AGENT_ID value]
+API contract: [paste the API contract summary]
+Files modified: [list files changed by the backend-builder]
+```
+
+---
+
+## Step 5.5 — Build Verification Gate
+
+Announce: "Step 5.5/8 — Verifying backend builds and tests pass before proceeding to frontend."
+
+Run the backend build:
+
+```bash
+dotnet build TaskFlow.Api --no-incremental
+```
+
+If the build fails: stop the pipeline. Display the full build error output. Ask using `AskUserQuestion`:
+
+- **Question:** "The backend build failed. How would you like to proceed?"
+- **Options:**
+  - "Send errors to backend-builder for fixes"
+  - "I'll fix it manually — hold the pipeline"
+  - "Abort the pipeline"
+
+If "Send errors to backend-builder for fixes": use `SendMessage` to `BACKEND_AGENT_ID` with the full build output and the instruction "The backend build failed after your implementation. Please fix the build errors below. Return a summary of what you changed." Then re-run this verification step.
+
+If "I'll fix it manually": pause. Wait for the user to confirm the build is clean before re-running this verification step.
+
+If "Abort the pipeline": stop immediately.
+
+If the build succeeds, run the tests:
+
+```bash
+dotnet test TaskFlow.Api.Tests --no-build
+```
+
+If tests fail: stop the pipeline, display the test failure output, and present the same three options above (substituting test failure output for build errors).
+
+If both build and tests pass: announce "Backend verified ✓ — proceeding to frontend implementation." and continue to Step 6.
+
 ---
 
 ## Step 6 — Implement the Frontend (frontend-builder)
 
 Announce: "Step 6/8 — Implementing the frontend with frontend-builder."
 
-**First, check whether this feature has frontend work.** Read the approved spec. If the spec explicitly states this is a backend-only change (e.g., a migration, an internal API used by other services, no UI changes), skip this step and proceed directly to Step 7, noting the skip.
+**First, ask the user explicitly** using `AskUserQuestion`:
 
-If frontend work is required, launch the `frontend-builder` agent. Pass it:
+- **Question:** "Does this feature require any frontend or UI changes?"
+- **Options:**
+  - "Yes — implement the frontend"
+  - "No — backend only, skip to Step 7"
+
+If "No — backend only": announce "Skipping frontend implementation — backend-only feature." and proceed directly to Step 7.
+
+Use `model: "sonnet"` for the frontend-builder agent. In the agent prompt, include: "Read `CLAUDE.md` at the project root before beginning. Pay particular attention to the Frontend section, API client patterns, hook conventions, testing patterns, and the Safe Change Rules."
+
+If "Yes — implement the frontend": launch the `frontend-builder` agent. Pass it:
 - The approved Technical Brief (full text)
 - The codebase-researcher findings (relevant frontend file paths, patterns, similar examples)
 - The API contract summary from the backend-builder (the new/changed endpoints, request/response shapes, status codes)
@@ -141,11 +238,50 @@ Wait for the agent to complete and return a summary of what was built.
 
 Do not proceed to Step 7 until the gate exits.
 
+**Record the frontend-builder agent ID** returned at the end of the agent result. Store it as `FRONTEND_AGENT_ID`. This ID is required for the Step 7 fix loop.
+
+**Review and commit the frontend implementation:**
+
+Run the following to show the user what the agent changed:
+
+```bash
+git add -A
+git diff --staged --stat
+git diff --staged
+```
+
+Present the diff output to the user, then ask using `AskUserQuestion`:
+
+- **Question:** "Review the frontend changes above. Ready to commit?"
+- **Options:**
+  - "Commit these changes"
+  - "I need to make adjustments first — hold the pipeline"
+
+If "I need to make adjustments first": pause. Do not commit. Wait for the user to indicate they are done with their adjustments, then re-run `git diff --staged` and re-ask.
+
+If "Commit these changes":
+
+```bash
+git commit -m "feat: implement frontend for [feature name]"
+```
+
+Announce the commit hash. If `git diff --staged` showed nothing, announce "Frontend agent committed its own changes — no additional commit needed." and continue.
+
+**Save frontend checkpoint:** Append to `docs/superpowers/pipeline-checkpoints/[branch-name]-progress.md`:
+
+```
+Stage: frontend-complete
+Frontend agent ID: [FRONTEND_AGENT_ID value]
+Files modified: [list files changed by the frontend-builder]
+```
+
 ---
 
 ## Step 7 — Validate the Implementation (implementation-validator)
 
 Announce: "Step 7/8 — Validating with implementation-validator."
+
+Use `model: "sonnet"` for this agent.
 
 Launch the `implementation-validator` agent. Pass it:
 - The approved Technical Brief as the spec document
@@ -167,10 +303,36 @@ Do not proceed to the CRITICAL findings check or Step 8 until the gate exits.
 Announce: "CRITICAL issues found — sending back for fixes."
 
 For each CRITICAL finding, determine which layer it belongs to:
-- **Backend CRITICAL findings** → re-launch `backend-builder` with the original approved spec and the full validator report, emphasising the backend CRITICAL findings.
-- **Frontend CRITICAL findings** → re-launch `frontend-builder` with the original approved spec, the API contract from the backend, and the full validator report, emphasising the frontend CRITICAL findings.
 
-Then re-launch `implementation-validator` with the same spec and the updated file lists. Run the `open-questions-gate` on the new validator output before evaluating findings.
+- **Backend CRITICAL findings** → use `SendMessage` to `BACKEND_AGENT_ID` (do NOT launch a new agent — the existing agent retains its full implementation context). The message must be:
+
+  ```
+  The implementation-validator has found CRITICAL issues in your backend implementation. Please fix them now. Do not change anything unrelated to these findings.
+
+  CRITICAL FINDINGS:
+  [Paste the backend CRITICAL findings from the validator report verbatim]
+
+  FULL VALIDATOR REPORT (for context):
+  [Paste the full validator report]
+
+  Return a summary of every file you changed and what you fixed.
+  ```
+
+- **Frontend CRITICAL findings** → use `SendMessage` to `FRONTEND_AGENT_ID` (do NOT launch a new agent). The message must be:
+
+  ```
+  The implementation-validator has found CRITICAL issues in your frontend implementation. Please fix them now. Do not change anything unrelated to these findings.
+
+  CRITICAL FINDINGS:
+  [Paste the frontend CRITICAL findings from the validator report verbatim]
+
+  FULL VALIDATOR REPORT (for context):
+  [Paste the full validator report]
+
+  Return a summary of every file you changed and what you fixed.
+  ```
+
+After receiving fix confirmation from the builder(s), re-launch `implementation-validator` with the same spec and the updated file lists. Run the `open-questions-gate` on the new validator output before evaluating findings.
 
 Repeat this loop a maximum of **two times**. If CRITICAL findings remain after two fix cycles, stop and surface all findings to the user with a clear statement: "Automated fix cycles exhausted. Human review required before proceeding."
 
@@ -190,13 +352,38 @@ Present to the user:
 
 Use `AskUserQuestion`: **"Implementation is complete. How would you like to proceed?"** with options: "Open a PR", "I have feedback — hold on", "Reject and discard".
 
-**If Open a PR:** Announce that you are pushing the branch and opening a PR. Run:
+**If Open a PR:** Run the following sequence. Stop if any command fails.
+
+First, check for any uncommitted changes left by the validation fix cycle:
+
+```bash
+git add -A
+git diff --staged --stat
+git diff --staged
+```
+
+If `git diff --staged` shows any changes, present them to the user and ask using `AskUserQuestion`:
+
+- **Question:** "These changes were made during the validation fix cycle. Review above — ready to commit?"
+- **Options:**
+  - "Commit these changes"
+  - "I need to make adjustments first — hold the pipeline"
+
+If adjustments needed: pause until the user confirms. Then re-run `git diff --staged` and re-ask.
+
+Once committed (or if there was nothing to commit), show the full commit list and push:
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Present the log to the user so they can see every commit that will be included in the PR. Then push:
 
 ```bash
 git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
 ```
 
-Then create a PR with a description summarising the feature and validator findings.
+Then create the PR with a description summarising the feature, the files changed, and the validator findings.
 
 **If I have feedback:** ask the user to describe the issue. Surface the full validator report and the spec for reference. Ask whether to: (a) fix a specific issue, (b) re-run the validator, or (c) loop back to implementation. Follow the user's direction.
 
@@ -231,10 +418,11 @@ git push + PR
 ## Rules
 
 - Always announce which step you are on before launching each agent or running a command.
-- Always run the `open-questions-gate` after every agent returns — it exits immediately if there are no open questions, so there is no cost to running it when not needed.
+- **Gate enforcement is mandatory.** After every agent returns (Steps 2, 3, 5, 6, 7), you MUST invoke `open-questions-gate` before doing anything else. Announce "Running open-questions-gate for [agent-type]" in your response — this announcement is the visible audit trail that the gate ran. If you are about to proceed to the next step and you cannot find this announcement in your recent output for the previous step, stop and run the gate now. The gate exits in one line when there are no questions; there is no cost to running it unnecessarily.
 - Never skip the human gates at Steps 4 and 8.
 - Never merge or combine two agent launches into one message.
 - Always pass the full spec text to both the builders and the validator — never summarise it.
 - Always use the finalized (post-gate) agent output when passing findings forward to the next stage.
 - If any agent returns an error or produces no output, stop and tell the user what failed before continuing.
 - If any Bash command fails, stop and ask the user to resolve the issue before proceeding.
+- Checkpoint files are written to `docs/superpowers/pipeline-checkpoints/`. If resuming an interrupted pipeline, read the most recent checkpoint file for that branch to reconstruct pipeline state before continuing.

--- a/.claude/skills/open-questions-gate/SKILL.md
+++ b/.claude/skills/open-questions-gate/SKILL.md
@@ -72,14 +72,17 @@ If the user selects "Accept agent default for this question": record the agent's
 
 If the user selects "Tell me more before I decide": explain the tradeoff in your next message (cite codebase implications if relevant), then re-present the same `AskUserQuestion` with its original options. Do not advance to the next question until a non-"Tell me more" option is selected.
 
-Once the user selects a final answer, record it and advance to the next question.
+Once the user selects a final answer, record it — noting whether it was an explicit choice or "Accept agent default for this question" — and advance to the next question.
 
-After all [N] questions are resolved, compile the resolution summary:
+After all [N] questions are resolved:
+
+- **If ALL answers were "Accept agent default for this question":** apply the **Accept Defaults Rule** (see Rules section) — exit this gate without revision.
+- **If ANY answer was an explicit choice:** compile the resolution summary including only the explicit answers (do not include questions left at agent default — the agent's output already reflects those choices):
 
 ```
 Resolved Answers:
-1. [Brief question label]: [User's answer]
-2. [Brief question label]: [User's answer]
+1. [Brief question label]: [User's explicit answer]
+2. [Brief question label]: [User's explicit answer]
 ```
 
 Proceed to Step D. (There is no Step C — it was consolidated into this step.)
@@ -165,9 +168,11 @@ AskUserQuestion: "Accept all agent defaults" or "Resolve them one by one"
 For each question:
   AskUserQuestion with agent options (or fallback: Yes/No/Tell me more/Accept default)
   "Tell me more" → explain tradeoff → re-present same question
-  Final answer recorded → advance to next question
+  Final answer recorded (explicit or default) → advance to next question
         ↓
-All questions resolved → compile Resolved Answers summary
+All questions resolved:
+  All answers = agent default → Apply Accept Defaults Rule → exit gate (no revision)
+  Any answer = explicit       → compile explicit Resolved Answers summary
         ↓
 SendMessage → same agent → revised output
         ↓
@@ -183,12 +188,12 @@ User approves revised output?
 
 ### Accept Defaults Rule
 
-When the user selects "Accept all agent defaults" (Step B up-front escape) or "Accept agent default for this question" (per-question option): announce "Accepting agent's stated defaults. Proceeding without revision." Do not send answers back to the agent. Exit this gate and continue the pipeline using the original unrevised output.
+When the user selects "Accept all agent defaults" (Step B up-front escape), or when ALL per-question answers resolve as "Accept agent default for this question" (every question resolved via the default option with no explicit choices made): announce "Accepting agent's stated defaults. Proceeding without revision." Do not send answers back to the agent. Exit this gate and continue the pipeline using the original unrevised output.
 
 **Early-stage risk:** When accepting defaults for a `codebase-researcher` or `spec-writer` output, display this warning before exiting the gate: "Warning: defaults accepted at this stage propagate to the backend-builder, frontend-builder, and implementation-validator. If an assumption is wrong, it may not surface until the final validation stage." Then exit normally. Do not block — this is informational only.
 
 - **Never skip this gate when open questions exist.** Unresolved questions passed to the next stage cause spec drift and implementation surprises.
-- **Never fabricate answers on the user's behalf.** Only the user's stated decisions go back to the agent. If the user accepts defaults instead of answering, pass only what the agent already stated as its own default.
+- **Never fabricate answers on the user's behalf.** Only explicit user decisions go back to the agent. Questions where the user accepted the agent default are not included in the resolution summary — the agent's output already reflects those choices.
 - **Always use `SendMessage`, not a new agent launch.** The existing agent retains its full output in context; a new agent would start cold.
 - **Pass user answers verbatim.** Do not paraphrase in ways that alter meaning or intent.
 - **One question at a time in discussion mode.** Keep focused — this is a decision gate, not a design session.

--- a/.claude/skills/open-questions-gate/SKILL.md
+++ b/.claude/skills/open-questions-gate/SKILL.md
@@ -19,7 +19,7 @@ Before entering this gate, you must have in context:
 
 - **Agent output** — the full text the agent returned
 - **Agent ID** — the identifier returned at the end of the agent result (format: `agentId: <id>`)
-- **Agent type** — human-readable label: `codebase-researcher`, `spec-writer`, `backend-feature-implementer`, or `implementation-validator`
+- **Agent type** — human-readable label: `codebase-researcher`, `spec-writer`, `backend-builder`, `frontend-builder`, or `implementation-validator`
 - **Output label** — what the agent was asked to produce: `research findings`, `Technical Brief`, `implementation`, or `validation report`
 
 ---
@@ -33,37 +33,48 @@ Scan the agent's full output for a section headed "Open Questions" or equivalent
 
 ---
 
-## Step B — Present Questions
+## Step B — Resolve Questions One by One
 
-Announce: "Open Questions Gate — [agent-type] returned [N] open question(s). Resolving before proceeding."
+Count the items listed under the Open Questions heading in the agent output. This is N — the total number of questions to resolve.
 
-Present the questions clearly, numbered, preserving any context or sub-options the agent included:
+Announce: "Open Questions Gate — [agent-type] returned [N] open question(s). Resolving now."
 
-```
-Open Question 1: [Question text]
-  Agent context: [Any tradeoff or background the agent noted]
+First, offer the up-front escape hatch using `AskUserQuestion`:
 
-Open Question 2: [Question text]
-  Agent context: [Any tradeoff or background the agent noted]
-```
-
-Then ask the user using `AskUserQuestion`:
-
-- **Question:** "How would you like to handle these open questions?"
+- **Question:** "How would you like to handle [N] open question(s) from the [agent-type]?"
 - **Options:**
-  - "Answer them now" — user will provide decisions in the next message
-  - "Discuss some first" — user wants to talk through tradeoffs before deciding
-  - "Accept agent defaults" — trust whatever assumptions the agent already stated
+  - "Resolve them one by one" — step through each question interactively
+  - "Accept all agent defaults" — trust whatever assumptions the agent stated
 
----
+If "Accept all agent defaults": see the **Accept Defaults Rule** in the Rules section and exit this gate.
 
-## Step C — Collect Answers
+If "Resolve them one by one": proceed through each question in sequence.
 
-### If "Answer them now"
+**For each question (loop: Question 1 of N, Question 2 of N, …):**
 
-Re-present the questions as a numbered list and ask the user to reply with one decision per question. Wait for their response.
+Display the question and its context as plain text before the `AskUserQuestion` call:
 
-Once all answers are received, compile a resolution summary:
+```
+Question [n] of [total]: [Full question text from agent output]
+Agent context: [Tradeoff or background the agent noted, if any — omit line if none]
+```
+
+Then call `AskUserQuestion`:
+
+- **Question:** "[Full question text from agent output]"
+- **Options:** Use the explicit choices the agent listed in its output for this question, if any. If the agent listed no choices, use:
+  - "Yes"
+  - "No"
+  - "Tell me more before I decide"
+  - "Accept agent default for this question"
+
+If the user selects "Accept agent default for this question": record the agent's stated default for that question (from the agent context line) as the answer, and advance to the next question.
+
+If the user selects "Tell me more before I decide": explain the tradeoff in your next message (cite codebase implications if relevant), then re-present the same `AskUserQuestion` with its original options. Do not advance to the next question until a non-"Tell me more" option is selected.
+
+Once the user selects a final answer, record it and advance to the next question.
+
+After all [N] questions are resolved, compile the resolution summary:
 
 ```
 Resolved Answers:
@@ -71,25 +82,7 @@ Resolved Answers:
 2. [Brief question label]: [User's answer]
 ```
 
-Proceed to Step D.
-
----
-
-### If "Discuss some first"
-
-Ask: "Which question would you like to discuss first?"
-
-Engage in focused discussion — explain tradeoffs, surface codebase implications, reference prior research findings if relevant. One question at a time. When the user decides, note the answer and ask: "Any other questions to discuss, or ready to submit all answers?"
-
-Once all questions are resolved, compile the resolution summary as above. Proceed to Step D.
-
----
-
-### If "Accept agent defaults"
-
-Announce: "Accepting agent's stated defaults for all open questions. Proceeding without revision."
-
-Exit this gate. Continue the pipeline using the original unrevised output.
+Proceed to Step D. (There is no Step C — it was consolidated into this step.)
 
 ---
 
@@ -103,7 +96,7 @@ Use `SendMessage` with the agent's ID to continue the **same agent** (do not lau
 The user has resolved the open questions listed in your output. Please revise your [output label] to incorporate these decisions. Only update the sections affected by the answers below — do not change anything else.
 
 RESOLVED QUESTIONS:
-[Paste the resolution summary from Step C verbatim]
+[Paste the resolution summary compiled in Step B verbatim]
 
 Return the complete revised [output label] with these decisions reflected.
 ```
@@ -140,7 +133,13 @@ Ask the user to describe what is still wrong. Compile the new feedback (treating
 
 Present the result and repeat Step E.
 
-**Maximum two additional revision cycles.** If the output is still not approved after two extra rounds, stop and surface this message: "Revision cycles exhausted — human review of the [agent-type] output is required before the pipeline can continue."
+**Maximum revision cycles by agent type:**
+- `spec-writer`: 5 cycles — specs often need multiple rounds of design feedback
+- `codebase-researcher`: 3 cycles
+- `backend-builder` or `frontend-builder`: 2 cycles — fixes should be targeted
+- `implementation-validator`: 2 cycles
+
+If the applicable cap is reached, stop and surface: "Revision cycles exhausted — human review of the [agent-type] output is required before the pipeline can continue."
 
 ---
 
@@ -160,28 +159,36 @@ Agent output received
 Open Questions present?
   No  → exit gate immediately
   Yes ↓
-Present questions to user
+AskUserQuestion: "Accept all agent defaults" or "Resolve them one by one"
+  "Accept all agent defaults" → warn if early stage → exit gate (no revision)
+  "Resolve them one by one"  ↓
+For each question:
+  AskUserQuestion with agent options (or fallback: Yes/No/Tell me more/Accept default)
+  "Tell me more" → explain tradeoff → re-present same question
+  Final answer recorded → advance to next question
         ↓
-User choice:
-  "Accept defaults" → exit gate (no revision)
-  "Answer now" / "Discuss first"
-        ↓
-Collect all answers
+All questions resolved → compile Resolved Answers summary
         ↓
 SendMessage → same agent → revised output
         ↓
 User approves revised output?
-  "Approved"        → exit gate → continue pipeline
-  "Still has issues" → one more revision cycle (max 2)
-  "Rejected"        → stop pipeline
+  "Approved"         → exit gate → continue pipeline
+  "Still has issues" → one more revision cycle (up to agent-type cap)
+  "Rejected"         → stop pipeline
 ```
 
 ---
 
 ## Rules
 
+### Accept Defaults Rule
+
+When the user selects "Accept all agent defaults" (Step B up-front escape) or "Accept agent default for this question" (per-question option): announce "Accepting agent's stated defaults. Proceeding without revision." Do not send answers back to the agent. Exit this gate and continue the pipeline using the original unrevised output.
+
+**Early-stage risk:** When accepting defaults for a `codebase-researcher` or `spec-writer` output, display this warning before exiting the gate: "Warning: defaults accepted at this stage propagate to the backend-builder, frontend-builder, and implementation-validator. If an assumption is wrong, it may not surface until the final validation stage." Then exit normally. Do not block — this is informational only.
+
 - **Never skip this gate when open questions exist.** Unresolved questions passed to the next stage cause spec drift and implementation surprises.
-- **Never fabricate answers on the user's behalf.** Only the user's stated decisions go back to the agent. If the user skips, pass only what the agent already stated as its own default.
+- **Never fabricate answers on the user's behalf.** Only the user's stated decisions go back to the agent. If the user accepts defaults instead of answering, pass only what the agent already stated as its own default.
 - **Always use `SendMessage`, not a new agent launch.** The existing agent retains its full output in context; a new agent would start cold.
 - **Pass user answers verbatim.** Do not paraphrase in ways that alter meaning or intent.
 - **One question at a time in discussion mode.** Keep focused — this is a decision gate, not a design session.


### PR DESCRIPTION
## Summary

- **open-questions-gate**: Rewrites the question-resolution UX to present one question at a time via `AskUserQuestion` with selectable options (replacing free-text bulk answers); adds accept-defaults risk warning for early pipeline stages; makes revision caps agent-type-aware (spec-writer gets 5 cycles, builders get 2); fixes stale agent-type label (`backend-feature-implementer` → `backend-builder`)
- **explore-then-build**: Fixes the `$USER_FEATURE_DESCRIPTION` shell variable bug in Step 1; adds token cost disclosure gate; replaces fragile spec-reading frontend detection with explicit `AskUserQuestion`; fixes CRITICAL loop to use `SendMessage` to original builder agents instead of cold re-launches; adds review-before-commit gates after each builder; fixes Step 8 to show `git log` before pushing; adds model selection per agent (Opus for spec-writer), CLAUDE.md context instructions, Step 5.5 build verification gate, pipeline checkpointing, and a strengthened gate enforcement rule

## Changes by file

**`.claude/skills/open-questions-gate/SKILL.md`**
- Step B rewritten: per-question loop with `AskUserQuestion`, N-count instruction, per-question accept-default recording
- Step C deleted (consolidated into Step B)
- `### Accept Defaults Rule` named section added with early-stage warning
- Revision cap table replaces hardcoded "2 cycles" (spec-writer=5, codebase-researcher=3, builders/validator=2)
- Required Context agent-type list corrected
- Gate Flow diagram updated

**`.claude/skills/explore-then-build/SKILL.md`**
- Step 1: token disclosure + cancel path + literal branch name (no shell variable)
- Step 2/3/5/6/7: model directives + CLAUDE.md read instructions per agent
- Step 5: BACKEND_AGENT_ID recording + review-then-commit block + checkpoint save
- Step 5.5 (new): `dotnet build` + `dotnet test` gate with SendMessage recovery path
- Step 6: AskUserQuestion frontend detection + FRONTEND_AGENT_ID recording + review-then-commit + checkpoint save
- Step 7 CRITICAL loop: `SendMessage` to stored agent IDs instead of re-launching
- Step 8: diff review + `git log` preview before push
- Rules: mandatory gate announcement requirement + checkpoint directory note

## Test plan

- [ ] Trigger `explore-then-build` on a new feature — confirm Step 1 shows token disclosure before any git commands
- [ ] Confirm branch name is derived from feature description without shell variable errors
- [ ] Trigger `open-questions-gate` with an agent output containing 3 questions — confirm each appears one at a time via `AskUserQuestion`
- [ ] Accept defaults on a spec-writer output — confirm the early-stage warning appears
- [ ] Reach Step 5 completion — confirm diff is shown and commit requires explicit approval before proceeding to Step 5.5
- [ ] Introduce a build error in the backend — confirm Step 5.5 stops and offers SendMessage recovery
- [ ] Reach Step 7 with a CRITICAL finding — confirm `SendMessage` is used to the original builder agent, not a new launch
- [ ] Reach Step 8 "Open a PR" — confirm `git log` is shown before `git push`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)