### PR TITLE
fix: resolve production CORS errors from hardcoded localhost baseUrl

### DIFF
--- a/TaskFlow.Web/openapi-ts.config.ts
+++ b/TaskFlow.Web/openapi-ts.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@hey-api/openapi-ts'
+
+export default defineConfig({
+  input: 'http://localhost:8080/openapi/v1.json',
+  output: {
+    path: './src/api/client',
+  },
+  plugins: [
+    {
+      name: '@hey-api/client-fetch',
+      baseUrl: false,
+    },
+    '@hey-api/typescript',
+    '@hey-api/sdk',
+  ],
+})

--- a/TaskFlow.Web/package.json
+++ b/TaskFlow.Web/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "type-check": "tsc -b --noEmit",
     "test": "vitest",
-    "gen:api": "openapi-ts --input http://localhost:8080/openapi/v1.json --output ./src/api/client --client @hey-api/client-fetch"
+    "gen:api": "openapi-ts"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/TaskFlow.Web/src/api/client/client.gen.ts
+++ b/TaskFlow.Web/src/api/client/client.gen.ts
@@ -13,4 +13,4 @@ import type { ClientOptions as ClientOptions2 } from './types.gen';
  */
 export type CreateClientConfig<T extends ClientOptions = ClientOptions2> = (override?: Config<ClientOptions & T>) => Config<Required<ClientOptions> & T>;
 
-export const client = createClient(createConfig<ClientOptions2>({ baseUrl: 'http://localhost:8080/' }));
+export const client = createClient(createConfig<ClientOptions2>());

--- a/TaskFlow.Web/src/api/client/types.gen.ts
+++ b/TaskFlow.Web/src/api/client/types.gen.ts
@@ -17,6 +17,7 @@ export type CreateJournalEntryDto = {
 
 export type CreateJournalLogEntryDto = {
     content: string;
+    taskItemId?: null | number | string;
 };
 
 export type CreateJournalNoteDto = {
@@ -56,6 +57,9 @@ export type JournalLogEntryResponseDto = {
     journalEntryId?: number | string;
     createdAt?: string;
     updatedAt?: null | string;
+    taskItemId?: null | number | string;
+    linkedTaskTitle?: null | string;
+    linkedTaskDeleted?: boolean;
 };
 
 export type JournalNoteResponseDto = {
@@ -117,6 +121,7 @@ export type UpdateJournalEntryDto = {
 
 export type UpdateJournalLogEntryDto = {
     content: string;
+    taskItemId: null | number | string;
 };
 
 export type UpdateJournalNoteDto = {

--- a/TaskFlow.Web/src/main.tsx
+++ b/TaskFlow.Web/src/main.tsx
@@ -2,8 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
+import { client } from './api/client/client.gen'
 import './index.css'
 import App from './App.tsx'
+
+client.setConfig({ baseUrl: import.meta.env.VITE_API_BASE_URL })
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary

- **Root cause:** `@hey-api/openapi-ts` 0.97 changed behavior to extract the `baseUrl` from the OpenAPI spec's `servers` list and bake `http://localhost:8080/` into the auto-generated `client.gen.ts`. In production, every API call targeted `localhost:8080` instead of the reverse proxy, triggering CORS failures and Chrome's Private Network Access block.
- **Fix (runtime):** `client.setConfig({ baseUrl: import.meta.env.VITE_API_BASE_URL })` in `main.tsx` overrides the generated default before React renders. `VITE_API_BASE_URL` is empty in `.env.production`, so production builds use relative paths that resolve via the existing reverse proxy — same origin, no CORS needed.
- **Fix (generator):** New `openapi-ts.config.ts` sets `baseUrl: false` on the `@hey-api/client-fetch` plugin so future `gen:api` runs never bake in a localhost URL again. `gen:api` script simplified to just `openapi-ts`.

## Test plan

- [x] All 280 frontend tests pass (`npm run test -- --run`)
- [x] Production build verified — `client.gen.ts` no longer contains `localhost:8080`
- [x] Dev environment unaffected — `VITE_API_BASE_URL=http://localhost:8080` in `.env.development` keeps direct-to-backend calls working
- [ ] Deploy to production and confirm API calls hit the correct origin (no CORS errors in browser console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)