### PR TITLE
chore: remove vestigial VITE_API_BASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,14 +271,7 @@ See [API Reference](docs/API.md) for request/response shapes and [API Versioning
 
 ### Frontend
 
-| File | `VITE_API_BASE_URL` | Used when |
-|------|-------------------|-----------|
-| `.env.development` | `http://localhost:8080` | `npm run dev` |
-| `.env.production` | *(empty)* | `npm run build` (Docker Compose image) |
-
-The generated SDK paths already include `/api/v1/...`, so `VITE_API_BASE_URL` must be the API origin only (e.g. `http://localhost:8080`) or left empty for same-origin deployments. Do not set it to `/api` — that would produce double-prefixed paths like `/api/api/v1/...`.
-
-In Docker Compose, `.env.production` is empty so the browser sends requests to the same origin (port 3000). The `vite preview` runtime server proxies `/api` and `/openapi` to `$API_TARGET` (`http://taskflow-api:8080` inside Docker network) — no CORS needed.
+No frontend environment variables are required. The API client uses relative paths by default — the Vite dev server proxies `/api` to `http://localhost:8080` in development, and `vite preview` proxies the same paths to `http://taskflow-api:8080` in Docker Compose. The browser sees same-origin requests in both cases.
 
 ## Testing
 

--- a/TaskFlow.Web/.env.development
+++ b/TaskFlow.Web/.env.development
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=http://localhost:8080

--- a/TaskFlow.Web/.env.production
+++ b/TaskFlow.Web/.env.production
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=

--- a/TaskFlow.Web/README.md
+++ b/TaskFlow.Web/README.md
@@ -75,7 +75,7 @@ TaskFlow.Web/
 ├── src/
 │   ├── api/
 │   │   ├── client/             # Auto-generated typed API client (do not edit manually)
-│   │   │   ├── client.gen.ts   # Client instance (baseUrl from VITE_API_BASE_URL)
+│   │   │   ├── client.gen.ts   # Client instance (relative paths by default)
 │   │   │   ├── sdk.gen.ts      # All generated API functions
 │   │   │   └── types.gen.ts    # All generated TypeScript types
 │   │   └── journal.ts          # Hand-written journal API functions + DTO types
@@ -104,8 +104,8 @@ TaskFlow.Web/
 │   ├── journal.css             # Journal page styles (scoped under .journal-page)
 │   ├── App.tsx                 # Router setup (/ → today's journal, /journal/:date, /tasks)
 │   └── main.tsx                # React root, QueryClient provider
-├── .env.development            # VITE_API_BASE_URL=http://localhost:8080
-├── .env.production             # VITE_API_BASE_URL= (empty — same-origin via vite preview proxy)
+├── .env.development            # (empty — Vite proxy handles /api → localhost:8080)
+├── .env.production             # (empty — reverse proxy handles /api routing)
 ├── vite.config.ts              # Vite config — @ alias, dev proxy, test config
 ├── Dockerfile                  # Multi-stage: build → vite preview
 └── package.json
@@ -128,7 +128,7 @@ npm run gen:api
 The generated files land in `src/api/client/`. Do not edit them manually — they will be overwritten on the next `gen:api` run. Commit the generated files to source control so the build is reproducible without a live API server.
 
 **How it works:**
-- `client.gen.ts` exports the configured client singleton (baseUrl from `VITE_API_BASE_URL`, `throwOnError: true` so failed requests propagate as errors to TanStack Query)
+- `client.gen.ts` exports the configured client singleton (relative paths by default, routed via Vite proxy in dev or the reverse proxy in production)
 - `sdk.gen.ts` exports one typed function per API endpoint (e.g. `getApiV1TaskItems`, `postApiV1TaskItems`)
 - `types.gen.ts` exports all request/response types derived from the OpenAPI schema
 
@@ -164,16 +164,13 @@ All server state (fetching, caching, mutation, invalidation) is encapsulated in 
 
 ## Configuration
 
-| File | Variable | Value | Used when |
-|------|----------|-------|-----------|
-| `.env.development` | `VITE_API_BASE_URL` | `http://localhost:8080` | `npm run dev` |
-| `.env.production` | `VITE_API_BASE_URL` | *(empty)* | `npm run build` (Docker Compose image) |
+No frontend environment variables are required. Both `.env.development` and `.env.production` are empty files.
 
-The generated SDK paths already include `/api/v1/...`, so `VITE_API_BASE_URL` must be the API origin only (e.g. `http://localhost:8080`) or left empty for same-origin deployments. Do not set it to `/api` — that would produce double-prefixed paths like `/api/api/v1/...`.
+The API client uses relative paths (`/api/v1/...`) by default. Routing is handled entirely by the proxy layer — no CORS configuration is needed:
+- **Dev:** Vite dev server proxies `/api` and `/openapi` to `http://localhost:8080`
+- **Docker Compose / production:** `vite preview` proxies the same paths to `$API_TARGET`
 
-In Docker Compose, `.env.production` uses an empty string so the browser sends requests to the same origin (port 3000). The `vite preview` server (configured in `vite.preview.config.js`) proxies `/api` and `/openapi` requests to `$API_TARGET` (`http://taskflow-api:8080` inside the Docker network). This removes the need for CORS and avoids exposing port 8080 to the browser.
-
-The Vite dev server proxy can be redirected via environment variable:
+The Vite dev server proxy target can be overridden via environment variable:
 
 ```bash
 API_TARGET=http://taskflow-api:8080 npm run dev

--- a/TaskFlow.Web/src/main.tsx
+++ b/TaskFlow.Web/src/main.tsx
@@ -2,11 +2,8 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
-import { client } from './api/client/client.gen'
 import './index.css'
 import App from './App.tsx'
-
-client.setConfig({ baseUrl: import.meta.env.VITE_API_BASE_URL })
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/docs/DOCKER_CONFIGURATION.md
+++ b/docs/DOCKER_CONFIGURATION.md
@@ -44,7 +44,7 @@ A single multi-stage .NET Dockerfile used for both dev and prod. The build conte
 
 **Frontend (`TaskFlow.Web/Dockerfile`)**
 
-A two-stage Node build. The build stage runs `npm run build`, baking `VITE_API_BASE_URL=` (empty) from `.env.production` into the bundle. Because the generated SDK paths already include `/api/v1/...` and the runtime stage serves via `vite preview` with a proxy, an empty base URL causes the browser to send requests to the same origin. The runtime stage serves the built files and proxies `/api` and `/openapi` to `$API_TARGET` via `vite.preview.config.js`.
+A two-stage Node build. The build stage runs `npm run build`. The API client uses relative paths by default (no env var needed), so the browser sends requests to the same origin. The runtime stage serves the built files and proxies `/api` and `/openapi` to `$API_TARGET` via `vite.preview.config.js`.
 
 | Aspect | Value |
 |--------|-------|
@@ -79,7 +79,7 @@ A two-stage Node build. The build stage runs `npm run build`, baking `VITE_API_B
 | **Image Tag** | `taskflow-web:dev` |
 | **Port Mapping** | `3000:3000` |
 | **Depends on** | `taskflow-api` (health check must pass) |
-| **`VITE_API_BASE_URL`** | *(empty — baked in at build time from `.env.production`)* |
+| **API routing** | Relative paths via `vite preview` proxy to `http://taskflow-api:8080` |
 
 The frontend container waits for `taskflow-api` to pass its health check before starting. The `vite preview` runtime server proxies `/api` and `/openapi` requests to `$API_TARGET` (`http://taskflow-api:8080` inside the Docker network), so the browser makes same-origin requests and no CORS configuration is required.
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -104,8 +104,8 @@ TaskFlow.Web/
 │   ├── main.tsx                    # React root — QueryClientProvider, RouterProvider
 │   └── index.css                   # Tailwind base import
 │
-├── .env.development                # VITE_API_BASE_URL=http://localhost:8080
-├── .env.production                 # VITE_API_BASE_URL= (empty — same-origin via vite preview proxy)
+├── .env.development                # (empty — Vite proxy handles /api → localhost:8080)
+├── .env.production                 # (empty — reverse proxy handles /api routing)
 ├── vite.config.ts                  # @ path alias, dev proxy, vitest config
 ├── tsconfig.app.json               # App TypeScript config
 ├── tsconfig.node.json              # Node/tooling TypeScript config
@@ -158,11 +158,13 @@ Two routes:
 
 ## API Client Generation
 
-The `gen:api` npm script invokes `@hey-api/openapi-ts`:
+The `gen:api` npm script invokes `@hey-api/openapi-ts` using the configuration in `openapi-ts.config.ts`:
 
 ```json
-"gen:api": "openapi-ts --input http://localhost:8080/openapi/v1.json --output ./src/api/client --client @hey-api/client-fetch"
+"gen:api": "openapi-ts"
 ```
+
+The config file sets `baseUrl: false` on the `@hey-api/client-fetch` plugin so the generator never bakes a hardcoded server URL into `client.gen.ts`. The generated client uses relative paths by default, which route through whatever proxy is in front (Vite in dev, the production reverse proxy in prod).
 
 **When to regenerate:**
 - After any change to the API's request/response shapes, routes, or model properties
@@ -171,14 +173,10 @@ The `gen:api` npm script invokes `@hey-api/openapi-ts`:
 **The generated client instance (`client.gen.ts`):**
 
 ```typescript
-export const client = createClient(createConfig<ClientOptions2>({
-  baseUrl: import.meta.env.VITE_API_BASE_URL ?? '',
-  throwOnError: true,
-}));
+export const client = createClient(createConfig<ClientOptions2>());
 ```
 
-- `baseUrl` is injected at build time from `VITE_API_BASE_URL`
-- `throwOnError: true` means non-2xx responses throw, which React Query routes to `isError` / `error` rather than treating as success
+With no `baseUrl` argument, `@hey-api/client-fetch` defaults to relative paths. All API call URLs (`/api/v1/...`) resolve against the current page origin.
 
 ## TanStack Query Hooks
 
@@ -304,16 +302,12 @@ Straightforward note display and edit forms. `NoteCard` shows content and timest
 
 ## Environment Configuration
 
-| File | `VITE_API_BASE_URL` | When used |
-|------|-------------------|-----------|
-| `.env.development` | `http://localhost:8080` | `npm run dev` |
-| `.env.production` | *(empty)* | `npm run build` (Docker Compose image) |
+No frontend environment variables are required. Both `.env.development` and `.env.production` are empty.
 
-`VITE_API_BASE_URL` is baked into the bundle at build time by Vite. The value must be the API **origin only** — the generated SDK paths already include `/api/v1/...`, so setting this to `/api` would produce double-prefixed requests like `/api/api/v1/...`.
+The generated API client uses relative paths (`/api/v1/...`) by default, and routing is handled entirely by the proxy layer:
 
-- **Docker Compose:** use an empty string — the `vite preview` runtime server proxies `/api` and `/openapi` to `$API_TARGET` (`http://taskflow-api:8080`), so the browser makes same-origin requests without CORS.
-- **Direct API access (no proxy):** use `http://localhost:8080` — the browser resolves requests to the API on port 8080 (requires CORS).
-- **Do not** set this to `/api` or any path prefix.
+- **Dev (`npm run dev`):** Vite's dev server proxies `/api` and `/openapi` to `http://localhost:8080` — same-origin to the browser, no CORS needed.
+- **Docker Compose / production:** `vite preview` (or the production reverse proxy) proxies `/api` and `/openapi` to the API container — same-origin to the browser, no CORS needed.
 
 ## Vite Dev Server Proxy
 
@@ -409,7 +403,7 @@ CMD ["node_modules/.bin/vite", "preview", "--config", "vite.preview.config.js", 
 **Key points:**
 - `npm ci` (not `npm install`) for reproducible installs in CI and Docker
 - `vite preview` serves the built files and handles SPA fallback (all unmatched paths → `index.html`)
-- The build stage bakes `VITE_API_BASE_URL=` (empty) from `.env.production` into the bundle
+- The API client uses relative paths by default — no env var needed at build time
 - `vite.preview.config.js` is copied into the runtime stage to configure the preview server proxy
 
 ### docker-compose.yml integration
@@ -429,7 +423,7 @@ taskflow-web:
       condition: service_healthy
 ```
 
-The web service waits for `taskflow-api` to pass its health check before starting. The frontend image is built with `VITE_API_BASE_URL=` (empty) from `.env.production`, so the browser sends same-origin requests to the `vite preview` server (port 3000). That server proxies `/api` and `/openapi` to `http://taskflow-api:8080` inside the Docker network via `vite.preview.config.js`. CORS configuration is not needed since all requests appear same-origin to the browser.
+The web service waits for `taskflow-api` to pass its health check before starting. The API client uses relative paths by default, so the browser sends same-origin requests to the `vite preview` server (port 3000). That server proxies `/api` and `/openapi` to `http://taskflow-api:8080` inside the Docker network via `vite.preview.config.js`. CORS configuration is not needed since all requests appear same-origin to the browser.
 
 > **Note for local dev:** Running `npm run dev` and `docker compose up` simultaneously may cause port conflicts on 5173 vs 3000 but not on 8080. The dev server proxies to port 8080 either way.
 
@@ -456,7 +450,7 @@ Failures in any step block the PR. The build step verifies the production bundle
 
 - Confirm the API is running: `curl http://localhost:8080/health`
 - If using `npm run dev`, check the Vite proxy is targeting the right host (default: `localhost:8080`)
-- If `VITE_API_BASE_URL` is wrong in `.env.development`, fix it and restart `npm run dev` (env changes require a restart)
+- If the Vite proxy is not routing correctly, check `vite.config.ts` — the proxy target defaults to `http://localhost:8080` and can be overridden with `API_TARGET`
 
 ### Status/priority filters not working
 
@@ -470,7 +464,7 @@ Run `npm run gen:api` with the API running at `http://localhost:8080` to regener
 
 - Check browser console for network errors
 - Verify CORS: the API's `appsettings.Development.json` must include the frontend origin in `Cors:AllowedOrigins`
-- Verify `VITE_API_BASE_URL` was correct at build time (it's baked in — rebuild the image if it changed)
+- Verify `vite.preview.config.js` proxy is pointing at the correct API target (`API_TARGET` env var, default `http://taskflow-api:8080`)
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -372,14 +372,9 @@ The generated files are committed to source control — you don't need a running
 
 ### Frontend environment variables
 
-| File | `VITE_API_BASE_URL` | Purpose |
-|------|-------------------|---------|
-| `.env.development` | `http://localhost:8080` | Used by `npm run dev` |
-| `.env.production` | *(empty)* | Baked into the Docker image at build time |
+No frontend environment variables are required. Both `.env.development` and `.env.production` are empty.
 
-The generated SDK paths already include `/api/v1/...`, so `VITE_API_BASE_URL` must be the API origin only or left empty for same-origin deployments. Do not set it to `/api` — that produces double-prefixed paths like `/api/api/v1/...`.
-
-In Docker Compose, `.env.production` is empty so the browser sends requests to the same origin. The `vite preview` runtime server proxies `/api` and `/openapi` to `$API_TARGET` (`http://taskflow-api:8080` inside the Docker network) — no CORS needed.
+The API client uses relative paths (`/api/v1/...`) by default. The Vite dev server proxies those to `http://localhost:8080` in development; in Docker Compose the `vite preview` server proxies them to `http://taskflow-api:8080`. Either way, the browser sees same-origin requests and no CORS configuration is needed.
 
 ### Vite proxy override
 


### PR DESCRIPTION
## Summary

- Removes `VITE_API_BASE_URL` from `.env.development` and `.env.production`
- Removes the `client.setConfig(...)` call from `main.tsx`

These were needed in PR #169 as a runtime override for the hardcoded `localhost:8080` that `@hey-api/openapi-ts` 0.97 was baking into `client.gen.ts`. Now that `openapi-ts.config.ts` sets `baseUrl: false`, the generated client has no hardcoded URL and defaults to relative paths — the Vite proxy in dev and the production reverse proxy both handle `/api` routing without any explicit configuration.

## Test plan

- [x] All 280 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)