### PR TITLE
fix: pin Microsoft.OpenApi to 2.7.5 to resolve CVE-2026-49451

### DIFF
--- a/TaskFlow.Api/TaskFlow.Api.csproj
+++ b/TaskFlow.Api/TaskFlow.Api.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftPlatformVersion)" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPlatformVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftPlatformVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftPlatformVersion)">


### PR DESCRIPTION
## Summary

- The main branch's periodic Trivy scan (and the check on open dependabot PRs #175-178) started failing today after CVE-2026-49451 was disclosed against `Microsoft.OpenApi` 2.0.0.
- `Microsoft.AspNetCore.OpenApi` 10.0.8 transitively pulls in the vulnerable `Microsoft.OpenApi` 2.0.0.
- Pinned an explicit `PackageReference` to `Microsoft.OpenApi` 2.7.5 (the patched release on the same major version, per the advisory) to force NuGet's resolution and avoid the 2.x→3.x breaking API changes.

## Note

- `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 also has an open advisory (CVE-2025-6965), but GitHub's advisory record shows `first_patched_version: null` — there's no fixed release to upgrade to yet, so nothing actionable there right now.

## Test plan

- [x] `dotnet restore` — `Microsoft.OpenApi` NU1903 warning no longer appears
- [x] `dotnet build TaskFlow.sln` — succeeds
- [x] `dotnet test TaskFlow.sln` — 252/252 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)