### PR TITLE
chore: configure worktree isolation for agent tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ TaskFlow.Api/tasks.db-wal
 /data/
 
 # End of file
+.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.env.local
+appsettings.Development.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Configuration
+
+isolation: worktree


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` to run agent tasks in isolated git worktrees (`isolation: worktree`)
- Add `.worktreeinclude` so gitignored local dev files (`.env`, `.env.local`, `appsettings.Development.json`) still get carried over into new worktree checkouts
- Ignore `.claude/worktrees/` in `.gitignore` so the worktree checkouts themselves aren't tracked

## Test plan
- [ ] Confirm a new agent worktree is created under `.claude/worktrees/` and is git-ignored
- [ ] Confirm `.env` / `appsettings.Development.json` are present in a freshly created worktree