### PR TITLE
docs: document full-replace vs merge-on-null semantics on UpdateTaskItemDto

### DIFF
--- a/TaskFlow.Api/DTOs/UpdateTaskItemDto.cs
+++ b/TaskFlow.Api/DTOs/UpdateTaskItemDto.cs
@@ -2,6 +2,19 @@ using TaskFlow.Api.Models;
 
 namespace TaskFlow.Api.DTOs;
 
+/// <summary>
+/// Update payload for <c>PUT /api/v1/TaskItems/{id}</c>. Field semantics are mixed:
+/// <list type="bullet">
+/// <item><description><b>Full-replace</b> — <see cref="Title"/>, <see cref="Description"/>,
+/// <see cref="IsComplete"/>, <see cref="DueDate"/>, and <see cref="ParentTaskItemId"/> always
+/// overwrite the existing value with whatever is sent, including <c>null</c>. Omitting
+/// <see cref="ParentTaskItemId"/> (or sending it as <c>null</c>) clears the task's parent link.</description></item>
+/// <item><description><b>Merge-on-null</b> — <see cref="Status"/> and <see cref="Priority"/> are
+/// only applied when non-null; a <c>null</c> value leaves the existing stored value unchanged.</description></item>
+/// </list>
+/// Callers must explicitly resend full-replace fields (e.g. <c>parentTaskItemId</c>) on every
+/// update or they will be cleared.
+/// </summary>
 public class UpdateTaskItemDto
 {
     public string Title { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- `UpdateTaskItemDto` mixes full-replace fields (`Title`, `Description`, `IsComplete`, `DueDate`, `ParentTaskItemId` — always overwritten, `null` clears them) with merge-on-null fields (`Status`, `Priority` — `null` leaves the stored value unchanged).
- This split was previously implicit in `TaskItemsController.Update` and masked by the frontend always sending an explicit `parentTaskItemId`. Adds an XML doc comment on the DTO making the contract explicit for any other consumer.
- No behavior change.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test TaskFlow.sln --filter "FullyQualifiedName~TaskItem"` — 65/65 passed

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)