### PR TITLE
fix: remove redundant null-coalescing after GetAllAsync() in TaskItemsController

### DIFF
--- a/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
+++ b/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
@@ -287,13 +287,13 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
 
     private async Task<bool> HasIncompleteChildrenAsync(int taskId)
     {
-        var allTasks = await _repo.GetAllAsync() ?? [];
+        var allTasks = await _repo.GetAllAsync();
         return allTasks.Any(t => t.ParentTaskItemId == taskId && !IsCompleted(t.IsComplete, t.Status));
     }
 
     private async Task<bool> HasChildrenAsync(int taskId)
     {
-        var allTasks = await _repo.GetAllAsync() ?? [];
+        var allTasks = await _repo.GetAllAsync();
         return allTasks.Any(t => t.ParentTaskItemId == taskId);
     }
 

--- a/docs/superpowers/pipeline-checkpoints/feature-issue-187-remove-redundant-null-coalescing-progress.md
+++ b/docs/superpowers/pipeline-checkpoints/feature-issue-187-remove-redundant-null-coalescing-progress.md
@@ -1,0 +1,5 @@
+Stage: backend-complete
+Backend agent ID: a89e4706634f9db04
+API contract: No API contract changes — private helper method internal cleanup only, no endpoint/route/DTO/status code changes.
+Files modified: TaskFlow.Api/Controllers/V1/TaskItemsController.cs (lines 289 and 295 — removed `?? []` from HasIncompleteChildrenAsync and HasChildrenAsync)
+Commit: ab5bcdb

--- a/docs/superpowers/pipeline-checkpoints/feature-issue-187-remove-redundant-null-coalescing-spec.md
+++ b/docs/superpowers/pipeline-checkpoints/feature-issue-187-remove-redundant-null-coalescing-spec.md
@@ -1,0 +1,134 @@
+# Technical Brief: Remove Redundant Null-Coalescing After GetAllAsync() in TaskItemsController
+
+**Date:** 2026-07-05
+**Status:** Draft
+**Author:** Spec Writer Agent
+
+## 1. Overview
+`TaskItemsController.HasIncompleteChildrenAsync` and `HasChildrenAsync` each apply a `?? []` null-coalescing guard to the result of `_repo.GetAllAsync()`, even though `ITaskRepository.GetAllAsync()` is declared to return a non-nullable `Task<IEnumerable<TaskItem>>` and the concrete `TaskRepository` implementation returns directly from EF Core's `ToListAsync()`, which never returns null. This is dead defensive code that is also applied inconsistently — four other call sites of the same method in the same file (`GetChildTaskCountAsync`, `TryAutoCompleteParentAsync`, `Delete`, `WouldCreateCycleAsync`) already omit the guard, as does the equivalent pattern in `JournalEntriesController.GetAll()`. This is a pure cleanup with zero behavior change.
+
+## 2. User Story
+```
+As a developer maintaining TaskFlow.Api,
+I want dead, misleading null-coalescing code removed from TaskItemsController,
+So that the codebase consistently reflects the true (non-nullable) contract of ITaskRepository.GetAllAsync() and future readers aren't misled into thinking null is a possible return value.
+```
+
+Acceptance criteria:
+1. The `?? []` expression is removed from line 290 (`HasIncompleteChildrenAsync`).
+2. The `?? []` expression is removed from line 296 (`HasChildrenAsync`).
+3. No other lines in `TaskItemsController.cs` are modified.
+4. `ITaskRepository.cs` and `TaskRepository.cs` are unchanged (their contracts already correctly reflect non-nullable return).
+5. All existing tests in `TaskItemsControllerV1Tests.cs` pass unchanged — no test file modifications are required or expected.
+6. `dotnet build` and `dotnet format --verify-no-changes` succeed with no new warnings.
+7. No public API contract, request/response shape, or HTTP status code changes.
+
+## 3. Data Model Changes
+No data model changes required.
+
+## 4. Backend Changes
+
+### 4a. New/Modified Endpoints
+No endpoint changes. This is a private-method-internal cleanup; no `[Http*]`-attributed action signatures, routes, request/response DTOs, or status codes are affected.
+
+### 4b. Repository Changes
+No repository changes. `ITaskRepository.GetAllAsync()` (`TaskFlow.Api/Repositories/ITaskRepository.cs:7`) and its implementation `TaskRepository.GetAllAsync()` (`TaskFlow.Api/Repositories/TaskRepository.cs:11-12`) remain untouched — they already correctly declare and return a non-nullable `IEnumerable<TaskItem>`.
+
+Two specific edits to `TaskFlow.Api/Controllers/V1/TaskItemsController.cs`:
+
+```csharp
+// Before (line 290)
+var allTasks = await _repo.GetAllAsync() ?? [];
+
+// After
+var allTasks = await _repo.GetAllAsync();
+```
+
+```csharp
+// Before (line 296)
+var allTasks = await _repo.GetAllAsync() ?? [];
+
+// After
+var allTasks = await _repo.GetAllAsync();
+```
+
+No other lines in the private helper methods (`GetChildTaskCountAsync`, `TryAutoCompleteParentAsync`, `Delete`, `WouldCreateCycleAsync`) or public actions change — they already call `GetAllAsync()` without a guard and are left as-is, since the issue scopes the fix to exactly these two call sites.
+
+### 4c. Validation
+No new or modified FluentValidation rules.
+
+### 4d. Service Registration / Extensions
+No changes to `Extensions/`.
+
+## 5. Frontend Changes
+No frontend changes. This is a backend-only cleanup with no public API contract change, so no frontend-builder step, `npm run gen:api` regeneration, or `src/api/journal.ts` update is needed.
+
+### 5a. API Client
+Not applicable — no API changes.
+
+### 5b. Components
+Not applicable.
+
+### 5c. Hooks / Data Fetching
+Not applicable.
+
+### 5d. Routing
+Not applicable.
+
+### 5e. Styling Notes
+Not applicable.
+
+## 6. Tests Required
+
+No new tests are required for this change. `TaskItemsControllerV1Tests.cs` already exercises `HasIncompleteChildrenAsync` and `HasChildrenAsync` indirectly through the controller actions that call them, and its shared setup (`TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs:26`) stubs `_mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync([]);` — an empty, non-null list. Since the mock never returns null, removing the `?? []` guards cannot change any test outcome, and the issue's own verification criterion states "Existing tests should pass unchanged; no behavior change."
+
+### 6a. Backend Tests
+No new test classes or test methods needed. Run the existing suite to confirm no regression:
+- `TaskItemsControllerV1Tests` — full existing suite — verifies no behavior change after removing the two guards (run `dotnet test --filter "FullyQualifiedName~TaskItemsControllerV1Tests"`).
+
+### 6b. Frontend Tests
+Not applicable — no frontend changes.
+
+### 6c. Coverage Impact
+Negligible/neutral. The change removes two dead branches (the `?? []` fallback) that were already unreachable given the repository's real behavior and the test mock's always-non-null setup; no coverage regression is expected since no reachable code path is deleted, and the CI 75% backend line-coverage gate is unaffected.
+
+## 7. Files That Will Change
+
+**New files:**
+None.
+
+**Modified files:**
+- `TaskFlow.Api/Controllers/V1/TaskItemsController.cs` — remove `?? []` from line 290 (`HasIncompleteChildrenAsync`) and line 296 (`HasChildrenAsync`).
+
+**Auto-generated (do not manually edit):**
+None — no API surface change, so `npm run gen:api` does not need to be run.
+
+## 8. Risks & Concerns
+
+1. **Risk:** Removing the guard could theoretically change behavior if a future or alternate `ITaskRepository` implementation (e.g., a test double or mock configured elsewhere) returns null from `GetAllAsync()`, causing a `NullReferenceException` at `.Any(...)` instead of silently treating it as empty.
+   **Likelihood:** Low
+   **Mitigation:** The interface contract (`Task<IEnumerable<TaskItem>>`, non-nullable) and the only concrete implementation (`TaskRepository`, backed by `ToListAsync()`) both guarantee non-null. This matches the codebase-wide convention (four other call sites in the same file, plus `JournalEntriesController.GetAll()`, already omit the guard). No enum/casing concerns apply here since this change touches no status/enum fields exposed to the frontend.
+
+2. **Risk:** Scope creep — a developer implementing this might be tempted to also "fix" the other four unguarded call sites or refactor `GetAllAsync()` usage into a single shared method, expanding the diff beyond what the issue requests.
+   **Likelihood:** Low
+   **Mitigation:** Per the issue, only lines 290 and 296 should change; the other four sites are already correct (no guard) and require no action. Keep the PR diff to exactly two line edits.
+
+## 9. Open Questions
+None. The issue description, verification criteria, and codebase findings are fully unambiguous and leave no product or technical decision unresolved.
+
+## 10. Implementation Order (Suggested)
+1. Edit `TaskFlow.Api/Controllers/V1/TaskItemsController.cs`: remove `?? []` from line 290 (`HasIncompleteChildrenAsync`).
+2. Edit the same file: remove `?? []` from line 296 (`HasChildrenAsync`).
+3. Run `dotnet build` to confirm no compile errors (no nullability warnings expected since the source expression type is already non-nullable `IEnumerable<TaskItem>`).
+4. Run `dotnet format --verify-no-changes` to confirm formatting compliance.
+5. Run `dotnet test --filter "FullyQualifiedName~TaskItemsControllerV1Tests"` (or the full suite) to confirm all existing tests pass unchanged.
+6. Commit with a Conventional Commits message, e.g. `chore: remove redundant null-coalescing after GetAllAsync() in TaskItemsController`, on a `bugfix/issue-187-...` or `chore/issue-187-...` branch, and open a PR referencing issue #187.
+
+---
+
+Relevant files read and verified during exploration:
+- `TaskFlow.Api/Controllers/V1/TaskItemsController.cs` (lines 280-379)
+- `TaskFlow.Api/Repositories/ITaskRepository.cs`
+- `TaskFlow.Api/Repositories/TaskRepository.cs` (lines 1-20)
+- `TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs` (lines 1-40)
+- `TaskFlow.Api/Controllers/V1/JournalEntriesController.cs` (lines 18-30)


### PR DESCRIPTION
## Summary
- `HasIncompleteChildrenAsync` and `HasChildrenAsync` in `TaskItemsController` applied a `?? []` guard to `_repo.GetAllAsync()`, even though the interface's non-nullable return type and the concrete `TaskRepository` (backed by EF Core's `ToListAsync()`) never return null.
- Removes the dead guard from both call sites, bringing them in line with the other four call sites of `GetAllAsync()` in the same file (and `JournalEntriesController.GetAll()`), which never had the guard.
- Pure cleanup — zero behavior change, no API contract change, no test changes needed.

## Test plan
- [x] `dotnet build` — succeeds, no new warnings
- [x] `dotnet format --verify-no-changes` — passes
- [x] `dotnet test` (full suite) — 262/262 passed
- [x] Implementation validated against the approved technical brief — 0 Critical, 0 Important, 1 Minor (methodology note, already addressed)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)