### PR TITLE
fix: remove unreachable nullable IJournalEntryRepository guard in TaskItemsController

### DIFF
--- a/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
+++ b/TaskFlow.Api/Controllers/V1/TaskItemsController.cs
@@ -10,7 +10,7 @@ namespace TaskFlow.Api.Controllers.V1;
 [ApiController]
 [ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> validator, IJournalEntryRepository? journalRepo = null) : ControllerBase
+public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> validator, IJournalEntryRepository journalRepo) : ControllerBase
 {
     private const string ApiVersionString = "1.0";
     private const string TaskCreationPastDayErrorCode = "TASK_CREATION_PAST_DAY_NOT_ALLOWED";
@@ -23,7 +23,7 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
     private const string ParentDeleteBlockedByChildrenErrorCode = "TASK_PARENT_DELETE_BLOCKED_BY_CHILDREN";
     private readonly ITaskRepository _repo = repo;
     private readonly IValidator<TaskItem> _validator = validator;
-    private readonly IJournalEntryRepository? _journalRepo = journalRepo;
+    private readonly IJournalEntryRepository _journalRepo = journalRepo;
 
     // GET: api/v1/TaskItems
     [HttpGet]
@@ -396,11 +396,6 @@ public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> vali
 
     private async Task AssignToJournalDateAsync(int taskId, DateOnly journalDate, int? timezoneOffsetMinutes = null)
     {
-        if (_journalRepo is null)
-        {
-            return;
-        }
-
         JournalEntry entry;
         try
         {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -290,17 +290,19 @@ TaskFlow.Api.Tests/
 public class TaskItemsControllerV1Tests
 {
     [Fact]
-    public async Task GetById_ReturnsNotFound_WhenTaskDoesNotExist()
+    public async Task Get_ReturnsNotFound_WhenTaskDoesNotExist()
     {
         // Arrange
         var mockRepo = new Mock<ITaskRepository>();
+        var mockValidator = new Mock<IValidator<TaskItem>>();
+        var mockJournalRepo = new Mock<IJournalEntryRepository>();
         mockRepo.Setup(r => r.GetByIdAsync(1))
                 .ReturnsAsync((TaskItem?)null);
 
-        var controller = new TaskItemsController(mockRepo.Object);
+        var controller = new TaskItemsController(mockRepo.Object, mockValidator.Object, mockJournalRepo.Object);
 
         // Act
-        var result = await controller.GetById(1);
+        var result = await controller.Get(1);
 
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();

--- a/docs/superpowers/pipeline-checkpoints/feature-issue-186-remove-dead-journalrepo-guard-progress.md
+++ b/docs/superpowers/pipeline-checkpoints/feature-issue-186-remove-dead-journalrepo-guard-progress.md
@@ -1,0 +1,5 @@
+Stage: backend-complete
+Backend agent ID: a216a5b7d195d7245
+API contract: No API contract change (internal refactor only).
+Files modified: TaskFlow.Api/Controllers/V1/TaskItemsController.cs, docs/CONTRIBUTING.md
+Commit: 942811c

--- a/docs/superpowers/pipeline-checkpoints/feature-issue-186-remove-dead-journalrepo-guard-spec.md
+++ b/docs/superpowers/pipeline-checkpoints/feature-issue-186-remove-dead-journalrepo-guard-spec.md
@@ -1,0 +1,201 @@
+# Technical Brief: Remove Nullable `IJournalEntryRepository` Dead-Code Guard in `TaskItemsController`
+
+**Date:** 2026-07-05
+**Status:** Approved
+**Author:** Spec Writer Agent
+
+## 1. Overview
+
+`TaskItemsController` declares its `IJournalEntryRepository` constructor parameter as optional and nullable (`IJournalEntryRepository? journalRepo = null`), and its private `AssignToJournalDateAsync` helper guards every use of the field with an `if (_journalRepo is null) { return; }` check. Since `IJournalEntryRepository` is registered unconditionally in DI (`PersistenceServiceExtensions.AddPersistence`) and the only test call site always supplies a mock, this null branch can never execute through any real code path — it is unreachable defensive code. This is a small, backend-only cleanup that tightens the constructor signature to match the pattern already used by every other journal-related controller (`JournalEntriesController`, `JournalTodosController`, `JournalNotesController`, `JournalLogEntriesController`), all of which take `IJournalEntryRepository journalRepo` as a required, non-nullable parameter. **Scope note:** this PR also bundles a small doc fix — the outdated `TaskItemsController` constructor example in `docs/CONTRIBUTING.md` (~line 300) will be corrected in the same PR (both the constructor call and the pre-existing `GetById`/`Get` method-name drift, in one coherent edit) rather than deferred, so the documentation stays fully consistent with the new non-nullable constructor signature and with the controller's real API.
+
+## 2. User Story
+
+```
+As a maintainer of the TaskFlow API,
+I want to remove unreachable null-guard code around IJournalEntryRepository in TaskItemsController,
+So that the codebase has less dead code, one fewer inconsistency with the rest of the journal controllers, and one less nullable branch for future maintainers to reason about.
+```
+
+Acceptance criteria:
+1. `TaskItemsController`'s constructor parameter `journalRepo` is declared as `IJournalEntryRepository journalRepo` (non-nullable, no default value), matching `JournalEntriesController`, `JournalTodosController`, `JournalNotesController`, and `JournalLogEntriesController`.
+2. The backing field `_journalRepo` is declared as `IJournalEntryRepository` (non-nullable).
+3. The `if (_journalRepo is null) { return; }` guard at the top of `AssignToJournalDateAsync` is removed.
+4. The remaining body of `AssignToJournalDateAsync` is otherwise unchanged (same logic, same exception handling for `DuplicateJournalDateException`).
+5. `dotnet build` produces no new nullable-reference-type (CS86xx) warnings.
+6. All existing tests in `TaskItemsControllerV1Tests` pass unchanged — no test file modifications are required.
+7. No public API contract changes: request/response shapes, status codes, and route signatures are identical before and after.
+8. No frontend changes are required or made.
+9. No EF Core migration is required or made.
+10. The `TaskItemsController` example in `docs/CONTRIBUTING.md` (~line 300, under "Testing Requirements" > "Writing Tests" > "Example unit test") is updated in the same PR so that (a) the constructor call passes all three required, non-nullable arguments, and (b) the method name matches the real `Get` action rather than the non-existent `GetById` — both corrections made together in one coherent edit.
+
+## 3. Data Model Changes
+
+No data model changes required. This issue touches only controller-level C# code (constructor signature, field declaration, and a private method body) plus a documentation example. No entities, migrations, or DbContext configuration are affected.
+
+## 4. Backend Changes
+
+### 4a. New/Modified Endpoints
+
+No endpoint signatures, routes, request/response shapes, or status codes change. `POST /api/v1/TaskItems` (the `Create` action, the only caller of `AssignToJournalDateAsync`) behaves identically before and after this change — the guard being removed was unreachable, so no observable behavior changes for any client.
+
+### 4b. Repository Changes
+
+None. `IJournalEntryRepository` and `JournalEntryRepository` are unmodified. No new or changed repository methods.
+
+### 4c. Validation
+
+None. No FluentValidation rules are added or changed.
+
+### 4d. Service Registration / Extensions
+
+None. `PersistenceServiceExtensions.AddPersistence` already registers `IJournalEntryRepository` unconditionally (`services.AddScoped<IJournalEntryRepository, JournalEntryRepository>();`, line 33) — this registration is what makes the null guard provably unreachable, and it requires no change.
+
+**Exact before/after for `TaskFlow.Api/Controllers/V1/TaskItemsController.cs`:**
+
+Constructor — before (line 13):
+```csharp
+public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> validator, IJournalEntryRepository? journalRepo = null) : ControllerBase
+```
+Constructor — after:
+```csharp
+public class TaskItemsController(ITaskRepository repo, IValidator<TaskItem> validator, IJournalEntryRepository journalRepo) : ControllerBase
+```
+
+Field — before (line 26):
+```csharp
+private readonly IJournalEntryRepository? _journalRepo = journalRepo;
+```
+Field — after:
+```csharp
+private readonly IJournalEntryRepository _journalRepo = journalRepo;
+```
+
+`AssignToJournalDateAsync` guard — before (lines 397–403):
+```csharp
+private async Task AssignToJournalDateAsync(int taskId, DateOnly journalDate, int? timezoneOffsetMinutes = null)
+{
+    if (_journalRepo is null)
+    {
+        return;
+    }
+
+    JournalEntry entry;
+```
+`AssignToJournalDateAsync` guard — after:
+```csharp
+private async Task AssignToJournalDateAsync(int taskId, DateOnly journalDate, int? timezoneOffsetMinutes = null)
+{
+    JournalEntry entry;
+```
+
+The rest of the method body (lines 404–434 in the current file — the `GetByDateAsync`/`AddAsync` fallback, the `DuplicateJournalDateException` catch block with its race-condition comment, and the final `AddTodoAsync` call) is untouched.
+
+**Exact before/after for `docs/CONTRIBUTING.md`:**
+
+Current content (lines 288–309, "Testing Requirements" > "Writing Tests" > "Example unit test"):
+```csharp
+public class TaskItemsControllerV1Tests
+{
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenTaskDoesNotExist()
+    {
+        // Arrange
+        var mockRepo = new Mock<ITaskRepository>();
+        mockRepo.Setup(r => r.GetByIdAsync(1))
+                .ReturnsAsync((TaskItem?)null);
+
+        var controller = new TaskItemsController(mockRepo.Object);
+
+        // Act
+        var result = await controller.GetById(1);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+}
+```
+
+Corrected sample (both the constructor call and the `GetById`→`Get` naming fixed together):
+```csharp
+public class TaskItemsControllerV1Tests
+{
+    [Fact]
+    public async Task Get_ReturnsNotFound_WhenTaskDoesNotExist()
+    {
+        // Arrange
+        var mockRepo = new Mock<ITaskRepository>();
+        var mockValidator = new Mock<IValidator<TaskItem>>();
+        var mockJournalRepo = new Mock<IJournalEntryRepository>();
+        mockRepo.Setup(r => r.GetByIdAsync(1))
+                .ReturnsAsync((TaskItem?)null);
+
+        var controller = new TaskItemsController(mockRepo.Object, mockValidator.Object, mockJournalRepo.Object);
+
+        // Act
+        var result = await controller.Get(1);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+}
+```
+
+## 5. Frontend Changes
+
+No frontend changes are required. This is a backend-only, internal refactor (plus a documentation correction) with no impact on the API contract, so `src/api/client/sdk.gen.ts` does not need regeneration and `src/api/journal.ts` does not need manual updates.
+
+## 6. Tests Required
+
+### 6a. Backend Tests
+
+No new tests are required, and no existing test code changes are required. `TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs` already constructs the controller with a non-null mock at every call site (constructor, line 28: `new TaskItemsController(_mockRepo.Object, _mockValidator.Object, _mockJournalRepo.Object)`), so all three tests that exercise `AssignToJournalDateAsync` continue to pass unchanged:
+
+- `Create_ShouldAssignToJournalDate_WhenJournalDateIsProvided`
+- `Create_ShouldSucceedAndAttachToExistingEntry_WhenJournalDateRaceOccurs`
+- `Create_ShouldForwardTimezoneOffsetToAddTodoAsync_WhenJournalDateIsToday`
+
+The `docs/CONTRIBUTING.md` fix is documentation-only and requires no test coverage.
+
+### 6c. Coverage Impact
+
+Neutral to slightly positive — deletes 4 never-covered lines. No risk to the 75% backend line-coverage gate.
+
+## 7. Files That Will Change
+
+- `TaskFlow.Api/Controllers/V1/TaskItemsController.cs` — non-nullable constructor param + field; remove null guard.
+- `docs/CONTRIBUTING.md` — fix stale example (constructor args + `GetById`→`Get`).
+
+## 8. Risks & Concerns
+
+1. Nullable-reference-type analyzer will catch any missed call site (Nullable enabled in csproj) — low risk, self-verifying via `dotnet build`.
+2. No other call site constructs `TaskItemsController` with a null/omitted third arg (DI is unconditional; only test call site already passes a mock) — verify with a repo-wide grep during implementation.
+3. Enum/PascalCase gotcha not applicable — no enum serialization touched.
+4. Docs fix touches a non-compiled example; must be edited coherently in one pass (constructor + method rename together) since no CI will validate the snippet.
+
+## 9. Open Questions
+
+None — resolved during the spec approval gate:
+- Docs fix bundled into this PR (not deferred).
+- `GetById`→`Get` naming drift fixed in the same edit as the constructor call.
+
+## 10. Implementation Order
+
+1. `TaskItemsController.cs`: constructor param `IJournalEntryRepository? journalRepo = null` → `IJournalEntryRepository journalRepo`.
+2. Field `_journalRepo` → non-nullable.
+3. Delete the `if (_journalRepo is null) { return; }` guard in `AssignToJournalDateAsync`.
+4. `dotnet build` — confirm no new nullable-reference-type warnings.
+5. `dotnet test --filter "FullyQualifiedName~TaskItemsControllerV1Tests"` — confirm unchanged pass.
+6. `dotnet format --verify-no-changes`.
+7. Full `dotnet test` suite.
+8. `docs/CONTRIBUTING.md`: fix example (constructor args + `GetById`→`Get`) per Section 4d.
+9. Commit as `fix: remove unreachable nullable IJournalEntryRepository guard in TaskItemsController`.
+
+---
+
+Relevant files reviewed:
+- `TaskFlow.Api/Controllers/V1/TaskItemsController.cs`
+- `TaskFlow.Api/Extensions/PersistenceServiceExtensions.cs`
+- `TaskFlow.Api/Repositories/IJournalEntryRepository.cs`
+- `TaskFlow.Api.Tests/Controllers/V1/TaskItemsControllerV1Tests.cs`
+- `TaskFlow.Api/TaskFlow.Api.csproj`
+- `docs/CONTRIBUTING.md`


### PR DESCRIPTION
## Summary
- Closes #186
- `TaskItemsController`'s constructor made `IJournalEntryRepository` non-nullable (dropping `? journalRepo = null`), and the backing field is now non-nullable, matching every other journal-related controller (`JournalEntriesController`, `JournalTodosController`, `JournalNotesController`, `JournalLogEntriesController`)
- Removed the `if (_journalRepo is null) { return; }` guard in `AssignToJournalDateAsync` — unreachable since `IJournalEntryRepository` is registered unconditionally in DI and the only test call site always passes a mock
- Bundled a small doc fix: corrected a stale `TaskItemsController` example in `docs/CONTRIBUTING.md` (missing constructor args, non-existent `GetById` renamed to `Get`)
- Depends on #179 (already merged into `main`)

## Test plan
- [x] `dotnet build` — clean, no new nullable-reference-type warnings
- [x] `dotnet test --filter "FullyQualifiedName~TaskItemsControllerV1Tests"` — 32/32 passed unchanged
- [x] `dotnet format --verify-no-changes` — no formatting diffs
- [x] Full `dotnet test` — 262/262 passed
- [x] Reviewed by implementation-validator: 0 CRITICAL / 0 IMPORTANT / 0 MINOR findings, all acceptance criteria met, no scope creep

🤖 Generated with [Claude Code](https://claude.com/claude-code)